### PR TITLE
Fixes before cbuild integration

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -28,7 +28,8 @@ func NewCli() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:          "cpackget",
-		Short:        "This utility installs/removes CMSIS-Packs",
+		Short:        "This utility adds/removes CMSIS-Packs",
+		Long:         "Please refer to the upstream repository for further information: https://github.com/Open-CMSIS-Pack/cpackget.",
 		SilenceUsage: true,
 		Run: func(cmd *cobra.Command, args []string) {
 			if flags.version {
@@ -45,9 +46,9 @@ func NewCli() *cobra.Command {
 		defaultPackRoot = ".cpackget/"
 	}
 
-	rootCmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Output the version number of cpackget and exit.")
-	rootCmd.PersistentFlags().CountP("verbosiness", "v", "Set verbosiness: None (Errors), -v (Info), -vv (Debugging).")
-	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specify pack root folder. Defaults to CMSIS_PACK_ROOT environment variable or current directory.")
+	rootCmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Prints the version number of cpackget and exit")
+	rootCmd.PersistentFlags().CountP("verbosiness", "v", "Sets verbosiness level: None (Errors), -v (Info), -vv (Debugging)")
+	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable or current directory")
 	_ = viper.BindPFlag("pack-root", rootCmd.PersistentFlags().Lookup("pack-root"))
 	_ = viper.BindPFlag("verbosiness", rootCmd.PersistentFlags().Lookup("verbosiness"))
 

--- a/cmd/commands/index.go
+++ b/cmd/commands/index.go
@@ -9,18 +9,23 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// overwrite is a flag that tells whether or not to overwrite current CMSIS_PACK_ROOT/.Web/index.pidx
+var overwrite bool
+
 var IndexCmd = &cobra.Command{
-	Use:               "index <index url>",
-	Short:             "Updates public index",
-	Long:              "Updates the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the file specified by the given url.",
+	Use:   "index <index url>",
+	Short: "Updates public index",
+	Long: `Updates the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the file specified by the given url.
+If there's already an index file, cpackget won't overwrite it. Use "-f" to do so.`,
 	PersistentPreRunE: configureInstaller,
 	Args:              cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Updating index %v", args)
 		indexPath := args[0]
-		return installer.UpdatePublicIndex(indexPath)
+		return installer.UpdatePublicIndex(indexPath, overwrite)
 	},
 }
 
 func init() {
+	IndexCmd.Flags().BoolVarP(&overwrite, "force", "f", false, "forces cpackget to overwrite an existing public index file")
 }

--- a/cmd/commands/index.go
+++ b/cmd/commands/index.go
@@ -10,13 +10,13 @@ import (
 )
 
 var IndexCmd = &cobra.Command{
-	Use:               "index <index-path>",
-	Short:             "Add public index",
-	Long:              "Add/overwrite the public index using the index path specified, it can be an local file or a URL",
+	Use:               "index <index url>",
+	Short:             "Updates public index",
+	Long:              "Updates the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the file specified by the given url.",
 	PersistentPreRunE: configureInstaller,
 	Args:              cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Infof("Changing index %v", args)
+		log.Infof("Updating index %v", args)
 		indexPath := args[0]
 		return installer.UpdatePublicIndex(indexPath)
 	},

--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -15,8 +15,8 @@ import (
 
 var PackCmd = &cobra.Command{
 	Use:               "pack",
-	Short:             "add/rm Open-CMSIS-Pack packages",
-	Long:              "Add or remove an Open-CMSIS-Pack from a local file or a file hosted somewhere else on the Internet.",
+	Short:             "Adds/Removes Open-CMSIS-Pack packages",
+	Long:              "Adds or removes Open-CMSIS-Pack packages from a local file or a file hosted somewhere else on the Internet.",
 	PersistentPreRunE: configureInstaller,
 }
 
@@ -30,12 +30,12 @@ var extractEula bool
 var packsListFileName string
 
 var packAddCmd = &cobra.Command{
-	Use:   "add <pack path>|-f <packs-list>",
-	Short: "Installs Open-CMSIS-Pack packages",
-	Long: `Installs a pack using the file specified in "<pack path>".
+	Use:   "add [<pack path> | -f <packs list>]",
+	Short: "Adds Open-CMSIS-Pack packages",
+	Long: `Adds a pack using the file specified in "<pack path>" or using packs URLs provided by "-f <packs list>".
 The file can be a local file or a file hosted somewhere else on the Internet.
-If it's hosted somewhere, cpackget will first download it. 
-The process consists of extracting all pack files into "CMSIS_PACK_ROOT/<vendor>/<packName>/<packVersion>/"`,
+If it's hosted somewhere, cpackget will first download it then extract all pack files into "CMSIS_PACK_ROOT/<vendor>/<packName>/<x.y.z>/"
+If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in the <packs list> file.`,
 	Args: cobra.MinimumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -85,11 +85,10 @@ var purge bool
 
 var packRmCmd = &cobra.Command{
 	Use:   "rm <pack reference>",
-	Short: "Uninstalls Open-CMSIS-Pack packages",
-	Long: `Uninstalls a pack using the reference "PackVendor.PackName[.x.y.z]",
-where the version "x.y.z" is optional. This will remove
-the pack from the reference index files. If files need
-to be actually removed, please use "--purge".`,
+	Short: "Removes Open-CMSIS-Pack packages",
+	Long: `Removes a pack using the reference "PackVendor.PackName[.x.y.z]".
+The version "x.y.z" is optional. This will remove the pack from the reference index files.
+Cache files (i.e. under CMSIS_PACK_ROOT/.Download/) are *NOT* removed. If cache files need to be actually removed, please use "--purge".`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Removing %v", args)
@@ -105,8 +104,8 @@ to be actually removed, please use "--purge".`,
 
 func init() {
 	packRmCmd.Flags().BoolVarP(&purge, "purge", "p", false, "forces deletion of cached pack files")
-	packAddCmd.Flags().BoolVarP(&skipEula, "agree-embedded-license", "a", false, "agree with the embedded license of the pack")
-	packAddCmd.Flags().BoolVarP(&extractEula, "extract-embedded-license", "x", false, "extract the embedded license of the pack and aborts the installation")
-	packAddCmd.Flags().StringVarP(&packsListFileName, "packs-list-filename", "f", "", "file with a list of packs urls, one per line")
+	packAddCmd.Flags().BoolVarP(&skipEula, "agree-embedded-license", "a", false, "agrees with the embedded license of the pack")
+	packAddCmd.Flags().BoolVarP(&extractEula, "extract-embedded-license", "x", false, "extracts the embedded license of the pack and aborts the installation")
+	packAddCmd.Flags().StringVarP(&packsListFileName, "packs-list-filename", "f", "", "specifies a file listing packs urls, one per line")
 	PackCmd.AddCommand(packAddCmd, packRmCmd)
 }

--- a/cmd/commands/pdsc.go
+++ b/cmd/commands/pdsc.go
@@ -10,18 +10,16 @@ import (
 )
 
 var PdscCmd = &cobra.Command{
-	Use:   "pdsc",
-	Short: "Add/remove packs in the local file system via PDSC files.",
-	Long: `<pack-path> can be a local file or a file hosted somewhere else on the Internet.
-cpack will extract information from it and install the files in specific directories inside this machine.`,
+	Use:               "pdsc",
+	Short:             "Adds or removes Open-CMSIS-Pack packages in the local file system via PDSC files.",
 	PersistentPreRunE: configureInstaller,
 }
 
 var pdscAddCmd = &cobra.Command{
-	Use:   "add </path/to/TheVendor.ThePack.x.y.z.pdsc>",
-	Short: "Adds the pdsc to the local repository index",
-	Long: `<pack-path> can be a local file or a file hosted somewhere else on the Internet.
-cpack will extract information from it and install the files in specific directories inside this machine.`,
+	Use:   "add <path/to/TheVendor.ThePack.x.y.z.pdsc>",
+	Short: "Adds a pack via pdsc file to the local repository index",
+	Long: `Adds a pack via pdsc file specified in <path/to/TheVendor.ThePack.x.y.z.pdsc>.
+cpackget will add the pdsc entry to CMSIS_PACK_ROOT/.Local/local_repository.pidx.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Adding pdsc")
@@ -37,10 +35,9 @@ cpack will extract information from it and install the files in specific directo
 
 var pdscRmCmd = &cobra.Command{
 	Use:   "rm <pack-name>",
-	Short: "Remove ",
-	Long: `<pack-name> should be in the format of "PackVendor.PackName.PackVersion".
-This will remove the pack from the reference index files. If files need to be actually removed,
-please use "cpackget purge <pack-name>"`,
+	Short: "Removes a pack installed via pdsc file from the local repository index",
+	Long: `Removes the pack referenced by the pdsc file specified in <pack-name>, e.g. "PackVendor.PackName.x.y.z".
+cpackget will remove the pdsc entry from CMSIS_PACK_ROOT/.Local/local_repository.pidx."`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Removing pdsc")

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -56,4 +56,7 @@ var (
 
 	// Cmdline errors
 	ErrIncorrectCmdArgs = errors.New("incorrect setup of command line arguments")
+
+	// Errors on installation strucuture
+	ErrCannotOverwritePublicIndex = errors.New("cannot overwrite original public index.pidx")
 )

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -290,9 +290,12 @@ func (p *PackType) uninstall(installation *PacksInstallationType) error {
 func (p *PackType) readEula() ([]byte, error) {
 	log.Debug("Reading EULA")
 
+	licenseFileName := strings.Replace(p.Pdsc.License, "\\", "/", -1)
+
 	// License contains the license path inside the pack file
 	for _, file := range p.zipReader.File {
-		if file.Name == p.Pdsc.License {
+		possibleLicense := strings.Replace(file.Name, "\\", "/", -1)
+		if possibleLicense == licenseFileName {
 
 			reader, _ := file.Open()
 			defer reader.Close()

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -112,8 +112,15 @@ func RemovePdsc(pdscPath string) error {
 }
 
 // UpdatePublicIndex receives a index path and place it under .Web/index.pidx.
-func UpdatePublicIndex(indexPath string) error {
+func UpdatePublicIndex(indexPath string, overwrite bool) error {
 	log.Debugf("Updating public index with \"%v\"", indexPath)
+
+	if utils.FileExists(Installation.PublicIndex) {
+		if !overwrite {
+			return errs.ErrCannotOverwritePublicIndex
+		}
+		log.Infof("Overwriting publix index file %v", Installation.PublicIndex)
+	}
 
 	var err error
 	if !strings.HasPrefix(indexPath, "https://") {
@@ -149,6 +156,7 @@ func SetPackRoot(packRoot string) error {
 	}
 	Installation.LocalPidx = xml.NewPidxXML(filepath.Join(Installation.LocalDir, "local_repository.pidx"))
 	Installation.PackIdx = filepath.Join(packRoot, "pack.idx")
+	Installation.PublicIndex = filepath.Join(Installation.WebDir, "index.pidx")
 
 	var err error
 	for _, dir := range []string{packRoot, Installation.DownloadDir, Installation.LocalDir, Installation.WebDir} {
@@ -182,6 +190,9 @@ type PacksInstallationType struct {
 	// WebDir stores "index.pidx" containing a list of PDSC tags with all
 	// publicly available packs.
 	WebDir string
+
+	// PublicIndex stores the path PackRoot/WebDir/index.pidx
+	PublicIndex string
 
 	// LocalPidx is a reference to "local_repository.pidx" that contains a flat
 	// list of PDSC tags representing all packs installed via PDSC files.

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -471,7 +471,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := nonPublicLocalPack123
 		addPack(t, packPath, ConfigType{
-			IsPublic: false,
+			CheckEula: true,
 		})
 	})
 

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -21,6 +21,7 @@ import (
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/net/html/charset"
 )
 
 // CacheDir is used for cpackget to temporarily host downloaded pack files
@@ -147,11 +148,10 @@ func ReadXML(path string, targetStruct interface{}) error {
 		return err
 	}
 
-	if err = xml.Unmarshal(contents, targetStruct); err != nil {
-		return err
-	}
-
-	return nil
+	reader := bytes.NewReader(contents)
+	decoder := xml.NewDecoder(reader)
+	decoder.CharsetReader = charset.NewReaderLabel
+	return decoder.Decode(targetStruct)
 }
 
 // WriteXML writes an XML struct to a file

--- a/cmd/utils/utils_test.go
+++ b/cmd/utils/utils_test.go
@@ -291,6 +291,19 @@ func TestReadXML(t *testing.T) {
 
 		assert.Equal(dummy.Contents, contents)
 	})
+
+	t.Run("test read encoding ascii", func(t *testing.T) {
+		contents := "Dummy content"
+		xmlFileName := "dummy.xml"
+		xmlFileContent := []byte("<?xml version='1.0' encoding='ASCII'?><dummy><contents>" + contents + "</contents></dummy>")
+		assert.Nil(ioutil.WriteFile(xmlFileName, xmlFileContent, 0600))
+		defer os.Remove(xmlFileName)
+
+		dummy := dummyXML{}
+		assert.Nil(utils.ReadXML(xmlFileName, &dummy))
+
+		assert.Equal(dummy.Contents, contents)
+	})
 }
 
 func TestWriteXML(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,5 @@ require (
 	github.com/spf13/cobra v1.1.3 // indirect
 	github.com/spf13/viper v1.8.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
-	golang.org/x/net v0.0.0-20211011170408-caeb26a5c8c0 // indirect
+	golang.org/x/net v0.0.0-20211020060615-d418f374d309 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -421,6 +421,8 @@ golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96b
 golang.org/x/net v0.0.0-20210505024714-0287a6fb4125/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211011170408-caeb26a5c8c0 h1:qOfNqBm5gk93LjGZo1MJaKY6Bph39zOKz1Hz2ogHj1w=
 golang.org/x/net v0.0.0-20211011170408-caeb26a5c8c0/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211020060615-d418f374d309 h1:A0lJIi+hcTR6aajJH4YqKWwohY4aW9RO7oRMcdv+HKI=
+golang.org/x/net v0.0.0-20211020060615-d418f374d309/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/scripts/test-public-index
+++ b/scripts/test-public-index
@@ -3,23 +3,14 @@
 echo "Attempting to install all publicly available packs found in www.keil.com/pack/keil.vidx"
 echo "Warning: this should only be used from time to time (possibly before releases) because it'll download dozens of GB of files"
 
-# Get the latest version of vidx2pidx to generate a flat list of packs
-curl -sL https://api.github.com/repos/open-cmsis-pack/vidx2pidx/releases/latest | jq -r '.assets[].browser_download_url' | grep linux | xargs wget -O ./tmp/vidx2pidx.tar.gz
-cd ./tmp
-trap cleanup INT TERM EXIT
-cleanup() {
-    rm -rf "vidx2pidx*" index.pidx packs_urls .cpackget .idxcache
-    cd ../
-}
+mkdir -p tmp
+cd tmp
 
-tar --extract --file=vidx2pidx.tar.gz --wildcards "*/vidx2pidx" --strip-components=1
-
-# Generate a flat list of public packs, to be saved in "index.pidx"
-./vidx2pidx https://www.keil.com/pack/keil.vidx
-grep '<pdsc' index.pidx | sed -e 's/.*vendor="//' -e 's/" url="/ /' -e 's/" name="/ /' -e 's/" version="/ /' -e 's/".*//' | awk '{print $2$1"."$3"."$4".pack"}' > packs_urls
+wget https://www.keil.com/pack/index.pidx
+grep '<pdsc' index.pidx | sed -e 's/.*url="/ /' -e 's/" vendor="/ /' -e 's/" name="/ /' -e 's/" version="/ /' -e 's/".*//' | awk '{print $1$2"."$3"."$4".pack"}' > packs_urls
 
 for u in `cat packs_urls`
 do
 	echo installing $u
-	../build/cpackget -v pack add $u && ../build/cpackget -v pack rm --purge `basename ${u::-5}`
+	../build/cpackget -v pack add --agree-embedded-license $u
 done


### PR DESCRIPTION
Hi @jkrech this PR fixes a small set of things for cpackget:

* Adds "--force" option when updating the public index file
* Standardizes help messages
* Accepts PDSC files with encoding other than utf-8 (cpackget does try to read the pdsc file just as a form of validation)

I have run a full installation of the public index in both cpackget and cp_install, and they are pretty much doing the same thing, which is good news! I have found that cpackget complains about the following (which I need your input on how to proceed)
1. Pack [ASN.Filter_Designer.1.0.2.pack](http://www.advsolned.com/armpack/ASN.Filter_Designer.1.0.2.pack) does **NOT** contain the PDSC file in the root of the zip file, it's actually inside the folder "ASN.Filter_Designer.1.0.2", it looks like a failure during pack creation
2. Pack [AutoChips.AC780x_DFP.1.0.5.pack](http://fex.autochips.com:90/download/CMSIS_PACK/AC7801/AutoChips.AC780x_DFP.1.0.5.pack) cp_install raised `file #92:  bad zipfile offset (local header sig):  7475784`
3. Pack [Nuvoton.NuMicroM7_DFP.1.0.1.pack](https://www.nuvoton.com/enu/Documents/KEILSoftwarePack/Nuvoton.NuMicroM7_DFP.1.0.1.pack) cpackget raised `x509: certificate signed by unknown authority`
4. Pack [Redpine.RS14100_DFP.1.0.6.pack](http://www.redpinesignals.com/downloads/keil_packs/RS14100_DFP/Redpine.RS14100_DFP.1.0.6.pack) cpackget raised `x509: certificate has expired or is not yet valid: current time 2021-10-21T15:44:42-03:00 is after 2021-08-27T23:59:59Z`
