### PR TITLE
Add packs using packid

### DIFF
--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -27,16 +27,17 @@ var (
 	ErrBadPackURL                  = errors.New("bad pack url: the url provided for this pack is malformed")
 
 	// Errors related to package content
-	ErrPdscFileNotFound     = errors.New("pdsc not found")
-	ErrPackAlreadyInstalled = errors.New("pack already installed")
-	ErrPackNotInstalled     = errors.New("pack not installed")
-	ErrPackNotPurgeable     = errors.New("pack not purgeable")
-	ErrPdscEntryExists      = errors.New("pdsc already in index")
-	ErrPdscEntryNotFound    = errors.New("pdsc not found in index")
-	ErrEula                 = errors.New("user does not agree with the pack's license")
-	ErrExtractEula          = errors.New("user wants to extract embedded license only")
-	ErrLicenseNotFound      = errors.New("embedded license not found")
-	ErrPackRootNotFound     = errors.New("pack root not found")
+	ErrPdscFileNotFound      = errors.New("pdsc not found")
+	ErrPackAlreadyInstalled  = errors.New("pack already installed")
+	ErrPackNotInstalled      = errors.New("pack not installed")
+	ErrPackNotPurgeable      = errors.New("pack not purgeable")
+	ErrPdscEntryExists       = errors.New("pdsc already in index")
+	ErrPdscEntryNotFound     = errors.New("pdsc not found in index")
+	ErrEula                  = errors.New("user does not agree with the pack's license")
+	ErrExtractEula           = errors.New("user wants to extract embedded license only")
+	ErrLicenseNotFound       = errors.New("embedded license not found")
+	ErrPackRootNotFound      = errors.New("pack root not found")
+	ErrPdscFileTooDeepInPack = errors.New("pdsc file is too deep in pack file")
 
 	// Errors related to network
 	ErrBadRequest            = errors.New("bad request")

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -66,6 +66,10 @@ var (
 
 	// Errors on installation strucuture
 	ErrCannotOverwritePublicIndex = errors.New("cannot overwrite original public index.pidx")
+	ErrPackNotFoundInPublicIndex  = errors.New("pack not found in the public index.pidx")
+	ErrPackPdscCannotBeFound      = errors.New("the URL for the pack pdsc file seems not to exist or it didn't return the file")
+	ErrPackVersionNotFoundInPdsc  = errors.New("pack version not found in the pdsc file")
+	ErrPackURLCannotBeFound       = errors.New("URL for the pack cannot be determined")
 
 	// Hack to allow multiple error logs while still avoiding duplicating the last error log
 	ErrAlreadyLogged = errors.New("already logged")

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -48,10 +48,12 @@ type PackType struct {
 
 // preparePack does some sanity validation regarding pack name
 // and check if it's public and if it's installed or not
-func preparePack(packPath string, short bool) (*PackType, error) {
+func preparePack(packPath string) (*PackType, error) {
 	pack := &PackType{
 		path: packPath,
 	}
+
+	var shortPath bool
 
 	// Clean out any possible query or user auth in the URL
 	// to help finding the correct path info
@@ -67,9 +69,12 @@ func preparePack(packPath string, short bool) (*PackType, error) {
 		url.RawQuery = ""
 
 		packPath = url.String()
+		shortPath = false
+	} else if !strings.HasSuffix(packPath, ".pack") && !strings.HasSuffix(packPath, ".zip") {
+		shortPath = true
 	}
 
-	info, err := utils.ExtractPackInfo(packPath, short)
+	info, err := utils.ExtractPackInfo(packPath, shortPath)
 	if err != nil {
 		return pack, err
 	}

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -42,6 +42,9 @@ type PackType struct {
 	// path points to a file in the local system, whether or not it's local
 	path string
 
+	// Subfolder stores the subfolder this pack is in the compressed file.
+	Subfolder string
+
 	// pdsc holds a pointer to the PDSC file already parsed as XML
 	Pdsc *xml.PdscXML
 
@@ -121,11 +124,19 @@ func (p *PackType) validate() error {
 	for _, file := range p.zipReader.File {
 		if filepath.Base(file.Name) == pdscFileName {
 
+			// Check if pack was compressed in a subfolder
+			subfoldersCount := strings.Count(file.Name, "/") + strings.Count(file.Name, "\\")
+			if subfoldersCount > 1 {
+				return errs.ErrPdscFileTooDeepInPack
+			} else if subfoldersCount == 0 {
+				p.Subfolder = filepath.Dir(file.Name)
+			}
+
 			// Read pack's pdsc
 			tmpPdscFileName := utils.RandStringBytes(10)
 			defer os.RemoveAll(tmpPdscFileName)
 
-			if err := utils.SecureInflateFile(file, tmpPdscFileName); err != nil {
+			if err := utils.SecureInflateFile(file, tmpPdscFileName, ""); err != nil {
 				return err
 			}
 
@@ -232,7 +243,7 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 
 	log.Debugf("Extracting files from \"%s\" to \"%s\"", p.path, packHomeDir)
 	for _, file := range p.zipReader.File {
-		err = utils.SecureInflateFile(file, packHomeDir)
+		err = utils.SecureInflateFile(file, packHomeDir, p.Subfolder)
 		if err != nil {
 			return err
 		}

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -204,7 +204,6 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 		log.Errorf("Can't decompress \"%s\": %s", p.path, err)
 		return errs.ErrFailedDecompressingFile
 	}
-	defer p.zipReader.Close()
 
 	if err = p.validate(); err != nil {
 		return err
@@ -245,9 +244,13 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 	for _, file := range p.zipReader.File {
 		err = utils.SecureInflateFile(file, packHomeDir, p.Subfolder)
 		if err != nil {
+			defer p.zipReader.Close()
 			return err
 		}
 	}
+
+	// Close zip file so Windows can't complain if we rename it
+	p.zipReader.Close()
 
 	pdscFileName := fmt.Sprintf("%s.%s.pdsc", p.Vendor, p.Name)
 	pdscFilePath := filepath.Join(packHomeDir, p.Pdsc.FileName)

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -28,6 +28,13 @@ func AddPack(packPath string, checkEula, extractEula bool) error {
 		return errs.ErrPackAlreadyInstalled
 	}
 
+	if pack.isPackID {
+		pack.path, err = FindPackURL(pack)
+		if err != nil {
+			return err
+		}
+	}
+
 	if err = pack.fetch(); err != nil {
 		return err
 	}
@@ -141,6 +148,134 @@ func UpdatePublicIndex(indexPath string, overwrite bool) error {
 	return utils.MoveFile(indexPath, filepath.Join(Installation.WebDir, "index.pidx"))
 }
 
+// PublicIndexUpdated is used by ensurePublicIndexIsUpdated to determine if the
+// public index already got updated in this run of cpackget
+var PublicIndexUpdated bool
+
+// PublicIndexURL points to keil today, may be read via a config file in the future
+var PublicIndexURL = "https://www.keil.com/pack/index.pidx"
+
+// ensurePublicIndexIsUpdated makes sure that the .Web/index.pidx
+func EnsurePublicIndexIsUpdated(forceUpdate bool) error {
+	log.Debugf("Ensuring public index exists and it's up to date (force update? %v)", forceUpdate)
+
+	if PublicIndexUpdated {
+		return nil
+	}
+
+	if forceUpdate || !utils.FileExists(Installation.PublicIndex) {
+		log.Infof("\"%s\" is missing, retrieving a fresh one from %s", Installation.PublicIndex, PublicIndexURL)
+		if err := UpdatePublicIndex(PublicIndexURL, true /* overwrite */); err != nil {
+			return err
+		}
+
+		PublicIndexUpdated = true
+	}
+
+	Installation.PublicIndexXML = xml.NewPidxXML(Installation.PublicIndex)
+	return Installation.PublicIndexXML.Read()
+}
+
+// FindPackURL uses pack.path as packID and try to find the pack URL
+// Finding step are as follows:
+// 1. Find pack.Vendor, pack.Name, pack.Version(optional) in Installation.PublicIndex
+//    1.1. if pack.Version == "", move to step 2
+//    1.2. if Installation.PublicIndex does not exist, call UpdatePublicIndex("https://www.keil.com/pack/index.pidx", true /* overwrite */) and repeat step 1
+//    1.3. if not found, raise errs.ErrPackNotFoundInPublicIndex
+//    1.4. read the PDSC tag into pdscTag
+//    1.5. packURL = pdscTag.URL + pack.Vendor + "." + pack.Name + "." + pack.Version + ".pack"
+//    1.6. if HTTP HEAD for packURL is not 200, move to step 2
+//    1.7. return packURL
+// 2. Find pack.Vendor, pack.Name in Installation.PublicIndex
+//    2.1. same as 1.2
+//    2.2. same as 1.3
+//    2.3. same as 1.4
+//    2.4. pdscURL = pdscTag.URL + pack.Vendor + "." + pack.Name + ".pdsc"
+//    2.5. if HTTP HEAD for pdscURL is not 200, raise errs.ErrPackPdscURLCannotBeFound
+//    2.6. read the PDSC file into pdscXML
+//    2.7. releastTag = pdscXML.FindReleaseTagByVersion(pack.Version) // if pack.Version == "", it'll return the most recent one
+//    2.8. if releaseTag == nil, raise errs.ErrPackVersionNotFoundInPdsc
+//    2.8. if releaseTag.URL == "", raise errs.ErrPackURLCannotBeFound
+//    2.9. return releaseTag.URL
+func FindPackURL(pack *PackType) (string, error) {
+	log.Debugf("Finding URL for \"%v\"", pack.path)
+
+	findPdscTag := func(pack *PackType) (*xml.PdscTag, error) {
+		pdscTag := Installation.PublicIndexXML.FindPdscTag(pack.PdscTag) // maybe _, ok := err.(*fs.PathError)
+		if pdscTag == nil {
+			// Public index may be outdated, force updating it
+			if err := EnsurePublicIndexIsUpdated(true); err != nil {
+				return nil, err
+			}
+
+			pdscTag := Installation.PublicIndexXML.FindPdscTag(pack.PdscTag)
+			if pdscTag == nil {
+				return nil, errs.ErrPackNotFoundInPublicIndex
+			}
+		}
+
+		return pdscTag, nil
+	}
+
+	if err := EnsurePublicIndexIsUpdated(false /* don't force */); err != nil {
+		return "", err
+	}
+
+	// First attempt to retrieve packURL straight out of .Web/index.pidx
+	pdscTag, err := findPdscTag(pack)
+	if err != nil {
+		return "", err
+	}
+
+	packURL := pdscTag.PackURL()
+	if utils.URLExists(packURL) {
+		pack.Version = pdscTag.Version
+		return packURL, nil
+	}
+
+	// Failed to find URL the easy way. Now do the hard way, through releases tag
+
+	// Get pack's pdsc file
+	packPdscFileName := filepath.Join(Installation.WebDir, pack.Vendor+"."+pack.Name+".pdsc")
+	if !utils.FileExists(packPdscFileName) {
+		packPdscURL := pdscTag.URL + filepath.Base(packPdscFileName)
+		log.Infof("\"%s\" not found, fetching it from \"%s\"", packPdscFileName, packPdscURL)
+
+		packPdscDownloadFilePath, err := utils.DownloadFile(packPdscURL)
+		if err != nil {
+			log.Error(err)
+			return "", errs.ErrPackPdscCannotBeFound
+		}
+
+		if err := utils.MoveFile(packPdscDownloadFilePath, packPdscFileName); err != nil {
+			return "", err
+		}
+	}
+
+	packPdscXML := xml.NewPdscXML(packPdscFileName)
+	if err := packPdscXML.Read(); err != nil {
+		return "", err
+	}
+
+	releaseTag := packPdscXML.FindReleaseTagByVersion(pack.Version)
+	if releaseTag == nil {
+		log.Errorf("Pack version \"%s\" was not found in \"%s\"", pack.Version, packPdscFileName)
+		return "", errs.ErrPackVersionNotFoundInPdsc
+	}
+
+	// Nowhere else to look for pack URL
+	if releaseTag.URL == "" {
+		return "", errs.ErrPackURLCannotBeFound
+	}
+
+	// Set the pack version, if empty
+	if pack.Version == "" {
+		pack.Version = releaseTag.Version
+	}
+
+	return releaseTag.URL, nil
+}
+
 // Installation is a singleton variable that keeps the only reference
 // to PacksInstallationType
 var Installation *PacksInstallationType
@@ -206,6 +341,9 @@ type PacksInstallationType struct {
 
 	// PublicIndex stores the path PackRoot/WebDir/index.pidx
 	PublicIndex string
+
+	// PublicIndexXML stores a xml.PidxXML reference for PackRoot/WebDir/index.pidx
+	PublicIndexXML *xml.PidxXML
 
 	// LocalPidx is a reference to "local_repository.pidx" that contains a flat
 	// list of PDSC tags representing all packs installed via PDSC files.

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -19,7 +19,7 @@ import (
 func AddPack(packPath string, checkEula, extractEula bool) error {
 	log.Debugf("Adding pack \"%v\"", packPath)
 
-	pack, err := preparePack(packPath, false)
+	pack, err := preparePack(packPath)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func AddPack(packPath string, checkEula, extractEula bool) error {
 func RemovePack(packPath string, purge bool) error {
 	log.Debugf("Removing pack \"%v\"", packPath)
 
-	pack, err := preparePack(packPath, true)
+	pack, err := preparePack(packPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -997,7 +997,6 @@ func TestAddPack(t *testing.T) {
 			assert.Nil(err)
 
 			pack := packInfoToType(packInfo)
-			fmt.Printf("paaaaaaaaaaaaaack %v\n", pack)
 			assert.True(installer.Installation.PackIsInstalled(pack))
 
 			packID := fmt.Sprintf("%s.%s.%s", pack.Vendor, pack.Name, pack.Version)

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -184,10 +184,14 @@ var (
 	packWithoutPdscFileInside      = filepath.Join(testDir, "PackWithout.PdscFileInside.1.2.3.pack")
 	packWithTaintedCompressedFiles = filepath.Join(testDir, "PackWith.TaintedFiles.1.2.3.pack")
 
+	// Packs with packid names only
+	publicRemotePack123PackID = "TheVendor.PublicRemotePack.1.2.3"
+	//publicRemotePackPackId = "TheVendor.PublicRemotePack"
+
 	// Public packs
 	publicLocalPack123  = filepath.Join(testDir, "1.2.3", "TheVendor.PublicLocalPack.1.2.3.pack")
 	publicLocalPack124  = filepath.Join(testDir, "1.2.4", "TheVendor.PublicLocalPack.1.2.4.pack")
-	publicRemotePack123 = filepath.Join(testDir, "1.2.3", "TheVendor.PublicRemotePack.1.2.3.pack")
+	publicRemotePack123 = filepath.Join(testDir, "1.2.3", publicRemotePack123PackID+".pack")
 
 	// Private packs
 	nonPublicLocalPack123  = filepath.Join(testDir, "1.2.3", "TheVendor.NonPublicLocalPack.1.2.3.pack")
@@ -226,6 +230,28 @@ var (
 func TestAddPack(t *testing.T) {
 
 	assert := assert.New(t)
+
+	//var newServer = func(contentBytes []byte) *httptest.Server {
+	//	return httptest.NewServer(
+	//		http.HandlerFunc(
+	//			func(w http.ResponseWriter, r *http.Request) {
+	//				reader := bytes.NewReader(contentBytes)
+	//				_, err := io.Copy(w, reader)
+	//				assert.Nil(err)
+	//			},
+	//		),
+	//	)
+	//}
+
+	//var new404Server = func() *httptest.Server {
+	//	return httptest.NewServer(
+	//		http.HandlerFunc(
+	//			func(w http.ResponseWriter, r *http.Request) {
+	//				w.WriteHeader(http.StatusNotFound)
+	//			},
+	//		),
+	//	)
+	//}
 
 	// Sanity tests
 	t.Run("test installing a pack with bad name", func(t *testing.T) {
@@ -610,6 +636,39 @@ func TestAddPack(t *testing.T) {
 		packPath := packWithSubFolder
 		addPack(t, packPath, ConfigType{})
 	})
+
+	// Install packs with pack id: Vendor.PackName[.x.y.z]
+	// install without a pack version
+	// install a pack that does not exist
+	//t.Run("test installing pack with pack id only", func(t *testing.T) {
+	//	localTestingDir := "test-add-pack-with-pack-id"
+	//	assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+	//	defer os.RemoveAll(localTestingDir)
+
+	//	// Create a server to serve the pack's pdsc file
+	//	zipContent, err := ioutil.ReadFile(publicRemotePack123PackId)
+	//	assert.Nil(err)
+	//	pdscServer := newServer(zipContent)
+
+	//	_, packBasePath := filepath.Split(publicRemotePack123)
+
+	//	packPath := packServer.URL + "/" + packBasePath
+
+	//	// create a public index
+	//	publicIndex := xml.NewPidxXML(installer.Installation.PublicIndex)
+	//	publicIndex.Read()
+
+	//	pdscTag := xml.PdscTag{
+	//		Vendor: "TheVendor",
+	//		URL: "lala",
+	//	}
+
+	//	//publicIndex.AddPdsc
+
+	//	addPack(t, packPath, ConfigType{
+	//		IsPublic: true,
+	//	})
+	//})
 }
 
 func TestRemovePack(t *testing.T) {

--- a/cmd/utils/security_test.go
+++ b/cmd/utils/security_test.go
@@ -44,7 +44,7 @@ func TestSecureInflateFile(t *testing.T) {
 	t.Run("test fail to inflate tainted file names", func(t *testing.T) {
 		zipFile := &zip.File{}
 		zipFile.Name = filepath.Join("..", "tainted-file")
-		err := utils.SecureInflateFile(zipFile, "")
+		err := utils.SecureInflateFile(zipFile, "", "")
 		assert.NotNil(err)
 		assert.True(errs.Is(err, errs.ErrInsecureZipFileName))
 	})
@@ -53,7 +53,7 @@ func TestSecureInflateFile(t *testing.T) {
 		dirName := "test-inflate-zip-dir"
 		zipFile := &zip.File{}
 		zipFile.Name = dirName + string(os.PathSeparator)
-		err := utils.SecureInflateFile(zipFile, "")
+		err := utils.SecureInflateFile(zipFile, "", "")
 		assert.Nil(err)
 		defer os.Remove(dirName)
 
@@ -67,7 +67,7 @@ func TestSecureInflateFile(t *testing.T) {
 		dirName := "test-inflate-zip-dir-forward-slash"
 		zipFile := &zip.File{}
 		zipFile.Name = dirName + "/"
-		err := utils.SecureInflateFile(zipFile, "")
+		err := utils.SecureInflateFile(zipFile, "", "")
 		assert.Nil(err)
 		defer os.Remove(dirName)
 
@@ -92,7 +92,7 @@ func TestSecureInflateFile(t *testing.T) {
 
 		// Inflate all files
 		for _, file := range zipReader.File {
-			assert.Nil(utils.SecureInflateFile(file, outDir))
+			assert.Nil(utils.SecureInflateFile(file, outDir, ""))
 		}
 
 		// Make sure files are OK

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -280,6 +280,17 @@ func IsTerminalInteractive() bool {
 	return (fileInfo.Mode() & os.ModeCharDevice) != 0
 }
 
+// URLExists checks whether a HEAD request to url is valid or not.
+func URLExists(url string) bool {
+	resp, err := HTTPClient.Head(url)
+	if err == nil {
+		exists := resp.StatusCode/100 == 2
+		resp.Body.Close()
+		return exists
+	}
+	return false
+}
+
 func init() {
 	rand.Seed(time.Now().UnixNano())
 	HTTPClient = &http.Client{}

--- a/cmd/xml/pdsc.go
+++ b/cmd/xml/pdsc.go
@@ -32,6 +32,7 @@ type ReleaseTag struct {
 	XMLName xml.Name `xml:"release"`
 	Version string   `xml:"version,attr"`
 	Date    string   `xml:"Date,attr"`
+	URL     string   `xml:"url,attr"`
 }
 
 // NewPdscXML receives a PDSC file name to be later read into the PdscXML struct

--- a/cmd/xml/pdsc.go
+++ b/cmd/xml/pdsc.go
@@ -53,6 +53,24 @@ func (p *PdscXML) LatestVersion() string {
 	return ""
 }
 
+// FindReleaseTagByVersion iterates over the PDSC file's releases tag and returns
+// the release that matching version.
+func (p *PdscXML) FindReleaseTagByVersion(version string) *ReleaseTag {
+	releases := p.ReleasesTag.Releases
+	if len(releases) > 0 {
+		if version == "" {
+			return &releases[0]
+		}
+
+		for _, releaseTag := range releases {
+			if releaseTag.Version == version {
+				return &releaseTag
+			}
+		}
+	}
+	return nil
+}
+
 // Tag returns a PdscTag representation of a PDSC file.
 func (p *PdscXML) Tag() PdscTag {
 	return PdscTag{

--- a/cmd/xml/pdsc_test.go
+++ b/cmd/xml/pdsc_test.go
@@ -75,4 +75,16 @@ func TestPdscXML(t *testing.T) {
 		assert.Equal(pdsc.Name, "DevPack")
 		assert.Equal(pdsc.LatestVersion(), "1.2.3")
 	})
+
+	t.Run("test finding release tag", func(t *testing.T) {
+		pdsc := xml.NewPdscXML("../../testdata/devpack/1.2.3/TheVendor.DevPack.pdsc")
+		assert.Nil(pdsc.Read())
+		releaseTag := pdsc.FindReleaseTagByVersion("1.2.3")
+		assert.NotNil(releaseTag)
+		assert.Equal(releaseTag.Version, "1.2.3")
+
+		releaseTag = pdsc.FindReleaseTagByVersion("")
+		assert.NotNil(releaseTag)
+		assert.Equal(releaseTag.Version, "1.2.3")
+	})
 }

--- a/cmd/xml/pidx.go
+++ b/cmd/xml/pidx.go
@@ -96,9 +96,31 @@ func (p *PidxXML) HasPdsc(pdsc PdscTag) bool {
 	return ok
 }
 
-// Key returns this pdscTag unique key.
-func (p *PdscTag) Key() string {
-	return p.Vendor + "." + p.Name + "." + p.Version
+// FindPdscTag takes in a sample pdscTag and returns the actual PDSC tag inside this PidxXML.
+func (p *PidxXML) FindPdscTag(pdsc PdscTag) *PdscTag {
+	log.Debugf("Searching for pdsc \"%s\"", pdsc.Key())
+	if pdsc.Version != "" {
+		foundTag, ok := p.pdscList[pdsc.Key()]
+		if ok {
+			log.Debugf("\"%s\" contains \"%s\"", p.fileName, pdsc.Key())
+			return &foundTag
+		}
+
+		log.Debugf("\"%s\" does not contain \"%s\"", p.fileName, pdsc.Key())
+		return nil
+	}
+
+	targetKey := pdsc.Key()
+	for key := range p.pdscList {
+		if strings.Contains(key, targetKey) {
+			log.Debugf("\"%s\" contains \"%s\": \"%s\"", p.fileName, pdsc.Key(), key)
+			foundTag := p.pdscList[key]
+			return &foundTag
+		}
+	}
+
+	log.Debugf("\"%s\" does not contain \"%s\"", p.fileName, pdsc.Key())
+	return nil
 }
 
 // Read reads FileName into this PidxXML struct and allocates memory for all PDSC tags.

--- a/cmd/xml/pidx.go
+++ b/cmd/xml/pidx.go
@@ -164,3 +164,13 @@ func (p *PidxXML) Write() error {
 
 	return utils.WriteXML(p.fileName, p)
 }
+
+// Key returns this pdscTag unique key.
+func (p *PdscTag) Key() string {
+	return p.Vendor + "." + p.Name + "." + p.Version
+}
+
+// PackURL constructs a URL of a pack using the tag's attributes.
+func (p *PdscTag) PackURL() string {
+	return p.URL + p.Key() + ".pack"
+}

--- a/cmd/xml/pidx_test.go
+++ b/cmd/xml/pidx_test.go
@@ -199,4 +199,38 @@ func TestPidxXML(t *testing.T) {
 		assert.NotNil(err)
 		assert.Equal(err.Error(), "XML syntax error on line 3: unexpected EOF")
 	})
+
+	t.Run("test finding pdsc tag", func(t *testing.T) {
+		fileName := utils.RandStringBytes(10) + ".pidx"
+		defer os.Remove(fileName)
+
+		pdscTag1 := xml.PdscTag{
+			Vendor:  "TheVendor",
+			URL:     "http://vendor.com/",
+			Name:    "ThePack",
+			Version: "0.0.1",
+		}
+
+		pdscTag2 := xml.PdscTag{
+			Vendor:  "TheVendor",
+			URL:     "http://vendor.com/",
+			Name:    "ThePack",
+			Version: "0.0.2",
+		}
+
+		pidx := xml.NewPidxXML(fileName)
+		assert.Nil(pidx.Read())
+
+		assert.Nil(pidx.AddPdsc(pdscTag1))
+		assert.Nil(pidx.AddPdsc(pdscTag2))
+
+		foundTag := pidx.FindPdscTag(pdscTag1)
+		assert.NotNil(foundTag)
+		assert.Equal(*foundTag, pdscTag1)
+
+		pdscTag1.Version = ""
+		foundTag = pidx.FindPdscTag(pdscTag1)
+		assert.NotNil(foundTag)
+		assert.Equal(foundTag.Version, "0.0.1")
+	})
 }

--- a/testdata/integration/EmptyPublicIndex.pidx
+++ b/testdata/integration/EmptyPublicIndex.pidx
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<index schemaVersion="1.1.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
+<vendor>TheVendor</vendor>
+<url>http://the.vendor/</url>
+<timestamp>2021-10-17T12:21:59.1747971+00:00</timestamp>
+<pindex>
+</pindex>
+</index>

--- a/testdata/integration/TheVendor.PublicRemotePack_EmptyURL.pdsc
+++ b/testdata/integration/TheVendor.PublicRemotePack_EmptyURL.pdsc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+   <vendor>TheVendor</vendor>
+   <url>http://vendor.com/packs/</url>
+   <name>PublicRemotePack</name>
+   <description>Sample pack just for testing</description>
+   <releases>
+      <!-- url attribute is intentionlly omitted -->
+      <release version="1.2.3" date="2016-09-15">New release.</release>
+   </releases>
+</package>

--- a/testdata/integration/TheVendor.PublicRemotePack_VersionNotAvailable.pdsc
+++ b/testdata/integration/TheVendor.PublicRemotePack_VersionNotAvailable.pdsc
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+   <vendor>TheVendor</vendor>
+   <url>http://vendor.com/packs/</url>
+   <name>PublicRemotePack</name>
+   <description>Sample pack just for testing</description>
+   <releases>
+      <!-- The pack used in this test has version 1.2.3 -->
+      <!-- <release version="1.2.2" date="2016-09-15">New release.</release> -->
+   </releases>
+</package>


### PR DESCRIPTION
Fix: https://github.com/Open-CMSIS-Pack/cpackget/issues/19

This PR does the following
1. Allows packID to be used to install packs:
1.1. Now the following pack add options are supported: `cpackget pack add ARM.mbedClient` or `cpackget pack add ARM.mbedClient.1.1.0` or `cpackget pack add http://www.keil.com/pack/ARM.mbedClient.1.1.0.pack` or `cpackget pack add ARM.mbedClient.1.1.0.pack`
2. It can find pack urls either using the pdsc URL + packID or via the url attribute in the release tag
2.1. If the url in the release tag end with some other file name, cpackget will make sure to name it to its proper pack file name when placing it under ".Download"
3. If a pack content is contained within a subfolder in the compressed file, cpackget will decompress that in the pack root folder, without the subfolder
3.1. If the pack content is under "compressedPack/contents", it'll be decompressed as "$CMSIS_PACK_ROOT/Vendor/PackName/x.y.z/contents", removing the "compressedPack" subfolder.