### PR TITLE
Tweaks for developing on Windows

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,7 +19,7 @@ Follow steps below to start developing for `cpackget`:
 `make test-all`
 
 6. Make sure it builds
-`make build/cpackget`
+`make build/cpackget` (Linux/MacOS) or `make build/cpackget.exe` (Windows)
 
 7. Done! You can now start changing the source code, please refer to [contributing guide](CONTRIBUTING.md) to start contributing to the project
 

--- a/makefile
+++ b/makefile
@@ -6,12 +6,17 @@ ARCH := $(or $(ARCH),$(ARCH),amd64)
 GOLINTER ?= golangci-lint
 GOFORMATTER ?= gofmt
 
+# CRLF config
+# ref: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#platform-all
+CRLF=input
+
 # Determine binary file name
 BIN_NAME := cpackget
 PROG := build/$(BIN_NAME)
 ifneq (,$(findstring indows,$(OS)))
     PROG=build/$(BIN_NAME).exe
     OS=windows
+    CRLF=true
 endif
 
 SOURCES := $(wildcard cmd/*.go) $(wildcard cmd/*/*.go)
@@ -89,6 +94,9 @@ config:
 	@echo "Configuring local environment"
 	@go version 2>/dev/null || echo "Need Golang: https://golang.org/doc/install"
 	@golangci-lint version 2>/dev/null || echo "Need GolangCi-Lint: https://golangci-lint.run/usage/install/#local-installation"
+
+	# Configure correct line endings
+	git config --global core.autocrlf $(CRLF)
 
 	# Install pre-commit hooks
 	cp scripts/pre-commit .git/hooks/pre-commit


### PR DESCRIPTION
This PR makes some changes regarding doing dev work on Windows:
1. Adds a note on DEVELOPING.md about building on Windows
2. Configure git auto.crlf depending on the OS

@jkrech I didn't adapt the makefile to detect whether it's being run on Windows on a bash or regular Windows cmd line because it was getting overly complex to check whether simple commands like `cp` or `rm` are available. Let's just assume that the developer is using bash on Windows with all these commands available. If you feel like this is a must, we can always get back at this.,