### PR TITLE
Verbose by default

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -45,10 +45,10 @@ func NewCli() *cobra.Command {
 
 	rootCmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Prints the version number of cpackget and exit")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run cpackget silently, printing only error messages")
-	rootCmd.PersistentFlags().BoolP("verbosiness", "v", false, "Sets verbosiness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
+	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
 	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable")
 	_ = viper.BindPFlag("pack-root", rootCmd.PersistentFlags().Lookup("pack-root"))
-	_ = viper.BindPFlag("verbosiness", rootCmd.PersistentFlags().Lookup("verbosiness"))
+	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	_ = viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 
 	for _, cmd := range commands.All {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -44,10 +44,12 @@ func NewCli() *cobra.Command {
 	defaultPackRoot := os.Getenv("CMSIS_PACK_ROOT")
 
 	rootCmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Prints the version number of cpackget and exit")
-	rootCmd.PersistentFlags().CountP("verbosiness", "v", "Sets verbosiness level: None (Errors), -v (Info), -vv (Debugging)")
+	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run cpackget silently, printing only error messages")
+	rootCmd.PersistentFlags().BoolP("verbosiness", "v", false, "Sets verbosiness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
 	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable")
 	_ = viper.BindPFlag("pack-root", rootCmd.PersistentFlags().Lookup("pack-root"))
 	_ = viper.BindPFlag("verbosiness", rootCmd.PersistentFlags().Lookup("verbosiness"))
+	_ = viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
 
 	for _, cmd := range commands.All {
 		rootCmd.AddCommand(cmd)

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -25,10 +25,10 @@ var createPackRoot bool
 
 // configureInstaller configures cpackget installer for adding or removing pack/pdsc
 func configureInstaller(cmd *cobra.Command, args []string) error {
-	verbosiness := viper.GetBool("verbosiness")
+	verbosiness := viper.GetBool("verbose")
 	quiet := viper.GetBool("quiet")
 	if quiet && verbosiness {
-		return errors.New("both \"-q\" and \"-v\" were specified, please pick only one verbosiness option")
+		return errors.New("both \"-q\" and \"-v\" were specified, please pick only one verboseness option")
 	}
 
 	log.SetLevel(log.InfoLevel)

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -5,7 +5,6 @@ package commands
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
 	log "github.com/sirupsen/logrus"
@@ -26,14 +25,21 @@ var createPackRoot bool
 
 // configureInstaller configures cpackget installer for adding or removing pack/pdsc
 func configureInstaller(cmd *cobra.Command, args []string) error {
-	logLevels := []log.Level{log.ErrorLevel, log.InfoLevel, log.DebugLevel}
-	maxVerbosiness := len(logLevels) - 1
-	verbosiness := viper.GetInt("verbosiness")
-	if verbosiness > maxVerbosiness {
-		errorMessage := fmt.Sprintf("Max verbosiness count is %v", maxVerbosiness)
-		return errors.New(errorMessage)
+	verbosiness := viper.GetBool("verbosiness")
+	quiet := viper.GetBool("quiet")
+	if quiet && verbosiness {
+		return errors.New("both \"-q\" and \"-v\" were specified, please pick only one verbosiness option")
 	}
-	log.SetLevel(logLevels[verbosiness])
+
+	log.SetLevel(log.InfoLevel)
+
+	if quiet {
+		log.SetLevel(log.ErrorLevel)
+	}
+
+	if verbosiness {
+		log.SetLevel(log.DebugLevel)
+	}
 
 	return installer.SetPackRoot(viper.GetString("pack-root"), createPackRoot)
 }


### PR DESCRIPTION
This patch makes cpackget verbose by default: Info + Error + Warning messages

If `--verbose/-v` is specified, debugging messages will be printed out. It's a LOT verbose.

If `--quiet/-q` is specified, only error messages will be printed out.

Here are some examples:
```bash
# Default verbosity
$ ./cpackget pack add ARM.CMSIS
I: Using pack root: "my-pack-root"
I: Adding [ARM.CMSIS]
Downloading ARM.CMSIS.5.8.0.pack 100% |█████████████████████████████████| (34/34 MB, 4.343 MB/s)        

# Be quiet
$ ./cpackget pack add -q ARM.CMSIS

# Be verbose (for dev debugging purposes)
$ ./cpackget pack add -v ARM.CMSIS
I: Using pack root: "my-pack-root"
D: Initializing PidxXML object for "my-pack-root/.Local/local_repository.pidx"
D: Initializing PidxXML object for "my-pack-root/.Web/index.pidx"
D: Making sure "my-pack-root" exists
D: Making sure "my-pack-root/.Download" exists
D: Making sure "my-pack-root/.Local" exists
D: Making sure "my-pack-root/.Web" exists
D: Reading pidx from file "my-pack-root/.Web/index.pidx"
... read all packs into an internal array ...
I: Adding [ARM.CMSIS]
D: Adding pack "ARM.CMSIS"
D: Extracting pack info from "ARM.CMSIS"
D: Listing files and directories in "my-pack-root/.Web" that match "^.*\.pdsc$"
D: Found "ARM.CMSIS.pdsc" in "my-pack-root/.Web"
D: Initializing PdscXML object for "my-pack-root/.Web/ARM.CMSIS.pdsc"
D: Reading pdsc from file "my-pack-root/.Web/ARM.CMSIS.pdsc"
D: Finding URL for "ARM.CMSIS"
D: Initializing PdscXML object for "my-pack-root/.Web/ARM.CMSIS.pdsc"
D: Reading pdsc from file "my-pack-root/.Web/ARM.CMSIS.pdsc"
D: Fetching pack file "http://www.keil.com/pack/ARM.CMSIS.5.8.0.pack" (or just making sure it exists locally)
D: Downloading http://www.keil.com/pack/ARM.CMSIS.5.8.0.pack to my-pack-root/.Download/ARM.CMSIS.5.8.0.pack
Downloading ARM.CMSIS.5.8.0.pack 100% |█████████████████████████████████| (34/34 MB, 4.343 MB/s)
... print out all files being unzipped ...
D: Copying file from "my-pack-root/ARM/CMSIS/5.8.0/ARM.CMSIS.pdsc" to "my-pack-root/.Download/ARM.CMSIS.5.8.0.pdsc"
```