### PR TITLE
Show progress when decompressing files

### DIFF
--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-cmsis-pack/cpackget/cmd/ui"
 	"github.com/open-cmsis-pack/cpackget/cmd/utils"
 	"github.com/open-cmsis-pack/cpackget/cmd/xml"
+	"github.com/schollz/progressbar/v3"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -284,7 +285,9 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 	}
 
 	log.Debugf("Extracting files from \"%s\" to \"%s\"", p.path, packHomeDir)
+	progress := progressbar.Default(int64(len(p.zipReader.File)), "I: Extracting files to "+packHomeDir)
 	for _, file := range p.zipReader.File {
+		_ = progress.Add(1)
 		err = utils.SecureInflateFile(file, packHomeDir, p.Subfolder)
 		if err != nil {
 			defer p.zipReader.Close()

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -64,7 +64,7 @@ func DownloadFile(URL string) (string, error) {
 	if log.GetLevel() != log.ErrorLevel {
 		progressWriter := progressbar.DefaultBytes(
 			resp.ContentLength,
-			"Downloading "+fileBase,
+			"I: Downloading "+fileBase,
 		)
 		writers = append(writers, progressWriter)
 	}


### PR DESCRIPTION
This is how it looks like now when installing a pack:

```
$ ./cpackget pack add -v ARM.CMSIS
I: Using pack root: "my-pack-root"
I: Adding [ARM.CMSIS]
I: Downloading ARM.CMSIS.5.8.0.pack 100% |██████████████████████████████| (34/34 MB, 7.945 MB/s)        
I: Extracting files to my-pack-root/ARM/CMSIS/5.8.0 100% |██████████████| (8133/8133, 9670 it/s)
```

Signed-off-by: Charles Oliveira <charles.oliveira@linaro.org>