### PR TITLE
Fix intermittent result on Windows

### DIFF
--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -167,7 +167,9 @@ func removePack(t *testing.T, packPath string, withVersion, isPublic, purge bool
 			// enough for the time delta below to show a difference
 			// Ref: https://www.lochan.org/2005/keith-cl/useful/win32time.html#timingwin
 			// So let's sleep a bit before checking for file mod times
-			time.Sleep(1 * time.Second)
+			// Sleeping for 1 second still caused interemittent results on Windows,
+			// bumping this up to 3 seconds
+			time.Sleep(3 * time.Second)
 		}
 
 		// Make sure the pack.idx file gets trouched


### PR DESCRIPTION
Uninstalling a pack means that the file pack.idx is touched, changing its modified time. This is later validated by cpackget
tests, meaning that the modified time of pack.idx before and after pack removal should be different.

Here's a pseudo code explaining the problem:

```
mtime_before = stat(pack.idx, mtime)
RemovePack() # should touch pack.idx, changing its modified time (mtime)
mtime_now = stat(pack.idx, mtime)
assert.True(mtime_before < mtime_now)
```

On Linux/Mac systems, the modified time is recorded with a higher precision if compared to Windows. So if the "RemovePack()" operation happens to run fast enough, both mtimes will be the same thus breaking the test depending on the load of the testing system at that specific time.

Since this is just a test thing, sleeping on windows should be fine to make sure this test runs correctly.