### PR TITLE
Display version of pack being installed

### DIFF
--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -63,7 +63,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 			return errs.ErrIncorrectCmdArgs
 		}
 
-		log.Infof("Adding %v", args)
+		log.Debugf("Specified packs %v", args)
 		var firstError error
 		for _, packPath := range args {
 			if err := installer.AddPack(packPath, !skipEula, extractEula); err != nil {

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -19,12 +19,13 @@ import (
 
 // AddPack adds a pack to the pack installation directory structure
 func AddPack(packPath string, checkEula, extractEula bool) error {
-	log.Debugf("Adding pack \"%v\"", packPath)
 
 	pack, err := preparePack(packPath)
 	if err != nil {
 		return err
 	}
+
+	log.Infof("Adding pack \"%s.%s.%s\"", pack.Vendor, pack.Name, pack.Version)
 
 	if !extractEula && pack.isInstalled {
 		return errs.ErrPackAlreadyInstalled


### PR DESCRIPTION
This prints out the pack version being installed

```bash
# Using pack id
$ ./cpackget pack add ARM.CMSIS
I: Using pack root: "my-pack-root"
I: Adding pack "ARM.CMSIS.5.8.0"
I: Downloading ARM.CMSIS.5.8.0.pack 100% |██████████████████████████████| (34/34 MB, 3.993 MB/s)        
I: Extracting files to my-pack-root/ARM/CMSIS/5.8.0 100% |██████████████| (8133/8133, 9664 it/s)

# Using local file
$ ./cpackget pack add ARM.CMSIS.5.7.0.pack 
I: Using pack root: "my-pack-root"
I: Adding pack "ARM.CMSIS.5.7.0"
I: Extracting files to my-pack-root/ARM/CMSIS/5.7.0 100% |██████████████| (6909/6909, 3148 it/s)        

# Using url
$ ./cpackget pack add https://keil.com/pack/ARM.CMSIS.5.7.0.pack
I: Using pack root: "my-pack-root"
I: Adding pack "ARM.CMSIS.5.7.0"
I: Downloading ARM.CMSIS.5.7.0.pack 100% |███████████████████████████| (111/111 MB, 5.022 MB/s)         
I: Extracting files to my-pack-root/ARM/CMSIS/5.7.0 100% |██████████████| (6909/6909, 3189 it/s)
```