### PR TITLE
Ux error messages

### DIFF
--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -70,7 +70,10 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 				if firstError == nil {
 					firstError = err
 				}
-				log.Error(err)
+
+				if !errs.AlreadyLogged(err) {
+					log.Error(err)
+				}
 			}
 		}
 

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -28,7 +28,6 @@ var (
 
 	// Errors related to package content
 	ErrPdscFileNotFound      = errors.New("pdsc not found")
-	ErrPackAlreadyInstalled  = errors.New("pack already installed")
 	ErrPackNotInstalled      = errors.New("pack not installed")
 	ErrPackNotPurgeable      = errors.New("pack not purgeable")
 	ErrPdscEntryExists       = errors.New("pdsc already in index")
@@ -36,7 +35,7 @@ var (
 	ErrEula                  = errors.New("user does not agree with the pack's license")
 	ErrExtractEula           = errors.New("user wants to extract embedded license only")
 	ErrLicenseNotFound       = errors.New("embedded license not found")
-	ErrPackRootNotFound      = errors.New("pack root not found")
+	ErrPackRootNotFound      = errors.New("no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option -R/--pack-root string")
 	ErrPdscFileTooDeepInPack = errors.New("pdsc file is too deep in pack file")
 
 	// Errors related to network
@@ -66,7 +65,7 @@ var (
 	ErrIncorrectCmdArgs = errors.New("incorrect setup of command line arguments")
 
 	// Errors on installation strucuture
-	ErrCannotOverwritePublicIndex = errors.New("cannot overwrite original public index.pidx")
+	ErrCannotOverwritePublicIndex = errors.New("cannot replace \"index.pidx\", use the flag \"-f/--force\" to force overwritting it")
 	ErrPackPdscCannotBeFound      = errors.New("the URL for the pack pdsc file seems not to exist or it didn't return the file")
 	ErrPackVersionNotFoundInPdsc  = errors.New("pack version not found in the pdsc file")
 	ErrPackURLCannotBeFound       = errors.New("URL for the pack cannot be determined. Please consider updating the public index. Ex: cpackget --force index https://keil.com/pack/index.pidx")

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -28,7 +28,8 @@ func AddPack(packPath string, checkEula, extractEula bool) error {
 	log.Infof("Adding pack \"%s.%s.%s\"", pack.Vendor, pack.Name, pack.Version)
 
 	if !extractEula && pack.isInstalled {
-		return errs.ErrPackAlreadyInstalled
+		log.Errorf("pack %s.%s.%s is already installed here: %s", pack.Vendor, pack.Name, pack.Version, filepath.Join(Installation.PackRoot, pack.Vendor, pack.Name, pack.Version))
+		return errs.ErrAlreadyLogged
 	}
 
 	if pack.isPackID {

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -66,7 +66,7 @@ func TestAddPack(t *testing.T) {
 		packPath = publicLocalPack123
 		err = installer.AddPack(packPath, !CheckEula, !ExtractEula)
 		assert.NotNil(err)
-		assert.Equal(err, errs.ErrPackAlreadyInstalled)
+		assert.Equal(err, errs.ErrAlreadyLogged)
 
 		// Make sure pack.idx did NOT get touched
 		packIdx, err = os.Stat(installer.Installation.PackIdx)


### PR DESCRIPTION
This PR improves the following error messages:
```
# Pack root initialization
$ ./cpackget init
I: Using pack root: ""
E: no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option "-R/--pack-root" string

# Pack already installed
$ ./cpackget pack add ARM.CMSIS
I: Using pack root: "my-pack-root/"
I: Adding pack "ARM.CMSIS.5.8.0"
E: pack ARM.CMSIS.5.8.0 is already installed here: my-pack-root/ARM/CMSIS/5.8.0

# Overwritting pack index
$ ./cpackget index https://keil.com/pack/index.pidx
I: Using pack root: "my-pack-root/"
I: Updating index [https://keil.com/pack/index.pidx]
E: cannot replace "index.pidx", use the flag "-f/--force" to force overwritting it
```