### PR TITLE
installer: support listing installed packs

### DIFF
--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -29,6 +29,12 @@ var extractEula bool
 // packsListFileName is the file name where a list of pack urls is present
 var packsListFileName string
 
+// listPublic tells whether listing all packs in the public index
+var listPublic bool
+
+// listCached tells whether listing all cached packs
+var listCached bool
+
 var packAddCmd = &cobra.Command{
 	Use:   "add [<pack path> | -f <packs list>]",
 	Short: "Adds Open-CMSIS-Pack packages",
@@ -106,10 +112,22 @@ Cache files (i.e. under CMSIS_PACK_ROOT/.Download/) are *NOT* removed. If cache 
 	},
 }
 
+var packListCmd = &cobra.Command{
+	Use:   "list [--cached|--public]",
+	Short: "Lists installed packs",
+	Long:  `Lists all installed packs and optionally cached pack files`,
+	Args:  cobra.MaximumNArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return installer.ListInstalledPacks(listCached, listPublic)
+	},
+}
+
 func init() {
 	packRmCmd.Flags().BoolVarP(&purge, "purge", "p", false, "forces deletion of cached pack files")
 	packAddCmd.Flags().BoolVarP(&skipEula, "agree-embedded-license", "a", false, "agrees with the embedded license of the pack")
 	packAddCmd.Flags().BoolVarP(&extractEula, "extract-embedded-license", "x", false, "extracts the embedded license of the pack and aborts the installation")
 	packAddCmd.Flags().StringVarP(&packsListFileName, "packs-list-filename", "f", "", "specifies a file listing packs urls, one per line")
-	PackCmd.AddCommand(packAddCmd, packRmCmd)
+	packListCmd.Flags().BoolVarP(&listCached, "cached", "c", false, "lists only cached packs")
+	packListCmd.Flags().BoolVarP(&listPublic, "public", "p", false, "lists packs in the public index")
+	PackCmd.AddCommand(packAddCmd, packRmCmd, packListCmd)
 }

--- a/cmd/installer/root_pack_list_test.go
+++ b/cmd/installer/root_pack_list_test.go
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package installer_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+	"github.com/open-cmsis-pack/cpackget/cmd/utils"
+	"github.com/open-cmsis-pack/cpackget/cmd/xml"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	ListCached = true
+	ListPublic = true
+)
+
+// Listing on empty
+func ExampleListInstalledPacks() {
+	localTestingDir := "test-list-empty-pack-root"
+	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
+	defer os.RemoveAll(localTestingDir)
+
+	log.SetOutput(os.Stdout)
+	defer log.SetOutput(ioutil.Discard)
+
+	_ = installer.ListInstalledPacks(!ListCached, !ListPublic)
+	// Output:
+	// I: Listing installed packs
+	// I: (no packs installed)
+}
+
+func ExampleListInstalledPacks_emptyCache() {
+	localTestingDir := "test-list-empty-cache"
+	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
+	defer os.RemoveAll(localTestingDir)
+
+	log.SetOutput(os.Stdout)
+	defer log.SetOutput(ioutil.Discard)
+
+	_ = installer.ListInstalledPacks(ListCached, !ListPublic)
+	// Output:
+	// I: Listing cached packs
+	// I: (no packs cached)
+}
+
+func ExampleListInstalledPacks_emptyPublicIndex() {
+	localTestingDir := "test-list-empty-index"
+	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
+	defer os.RemoveAll(localTestingDir)
+
+	log.SetOutput(os.Stdout)
+	defer log.SetOutput(ioutil.Discard)
+
+	_ = installer.ListInstalledPacks(ListCached, ListPublic)
+	// Output:
+	// I: Listing packs from the public index
+	// I: (no packs in public index)
+}
+
+// Now list 3 packs from the public index, where
+// * 1 is cached only
+// * 1 is installed
+// * 1 is neither installer or cached, it's just available in the public index
+func ExampleListInstalledPacks_list() {
+	localTestingDir := "test-list-packs"
+	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
+	defer os.RemoveAll(localTestingDir)
+
+	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
+	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.3",
+	})
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.4",
+	})
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.5",
+	})
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula)
+	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/)
+
+	log.SetOutput(os.Stdout)
+	defer log.SetOutput(ioutil.Discard)
+	_ = installer.ListInstalledPacks(ListCached, ListPublic)
+	// Output:
+	// I: Listing packs from the public index
+	// I: TheVendor.PublicLocalPack.1.2.3 (cached)
+	// I: TheVendor.PublicLocalPack.1.2.4 (installed)
+	// I: TheVendor.PublicLocalPack.1.2.5
+}
+
+func ExampleListInstalledPacks_listCached() {
+	localTestingDir := "test-list-cached-packs"
+	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
+	defer os.RemoveAll(localTestingDir)
+
+	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
+	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.3",
+	})
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.4",
+	})
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.5",
+	})
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula)
+	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/)
+
+	log.SetOutput(os.Stdout)
+	defer log.SetOutput(ioutil.Discard)
+	_ = installer.ListInstalledPacks(ListCached, !ListPublic)
+	// Output:
+	// I: Listing cached packs
+	// I: TheVendor.PublicLocalPack.1.2.3
+	// I: TheVendor.PublicLocalPack.1.2.4 (installed)
+}
+
+func ExampleListInstalledPacks_listInstalled() {
+	localTestingDir := "test-list-installed-packs"
+	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
+	defer os.RemoveAll(localTestingDir)
+
+	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
+	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.3",
+	})
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.4",
+	})
+	_ = installer.Installation.PublicIndexXML.AddPdsc(xml.PdscTag{
+		Vendor:  "TheVendor",
+		Name:    "PublicLocalPack",
+		Version: "1.2.5",
+	})
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula)
+	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/)
+
+	log.SetOutput(os.Stdout)
+	defer log.SetOutput(ioutil.Discard)
+	_ = installer.ListInstalledPacks(!ListCached, !ListPublic)
+	// Output:
+	// I: Listing installed packs
+	// I: TheVendor.PublicLocalPack.1.2.4
+}

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -5,6 +5,7 @@ package installer_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,14 +13,25 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
 	"github.com/open-cmsis-pack/cpackget/cmd/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+// Copy of cmd/log.go
+type LogFormatter struct{}
+
+func (s *LogFormatter) Format(entry *log.Entry) ([]byte, error) {
+	level := strings.ToUpper(entry.Level.String())
+	msg := fmt.Sprintf("%s: %s\n", level[0:1], entry.Message)
+	return []byte(msg), nil
+}
 
 func packInfoToType(info utils.PackInfo) *installer.PackType {
 	pack := &installer.PackType{}
@@ -447,4 +459,9 @@ func TestSetPackRoot(t *testing.T) {
 		// Now just make sure it's usable, even when not forced to initialize
 		assert.Nil(installer.SetPackRoot(localTestingDir, !CreatePackRoot))
 	})
+}
+
+func init() {
+	log.SetLevel(log.InfoLevel)
+	log.SetFormatter(new(LogFormatter))
 }

--- a/cmd/xml/pidx.go
+++ b/cmd/xml/pidx.go
@@ -96,6 +96,11 @@ func (p *PidxXML) HasPdsc(pdsc PdscTag) bool {
 	return ok
 }
 
+// ListPdscs returns a map of PdscTags in the pidx document
+func (p *PidxXML) ListPdscs() map[string]PdscTag {
+	return p.pdscList
+}
+
 // FindPdscTag takes in a sample pdscTag and returns the actual PDSC tag inside this PidxXML.
 func (p *PidxXML) FindPdscTag(pdsc PdscTag) *PdscTag {
 	log.Debugf("Searching for pdsc \"%s\"", pdsc.Key())

--- a/testdata/integration/1.2.3/TheVendor.PublicLocalPack.pdsc
+++ b/testdata/integration/1.2.3/TheVendor.PublicLocalPack.pdsc
@@ -5,6 +5,7 @@
    <name>PublicLocalPack</name>
    <description>Sample pack just for testing</description>
    <releases>
+      <release version="1.2.4" date="2016-09-15">New release.</release>
       <release version="1.2.3" date="2016-09-15">New release.</release>
       <release version="1.2.2">Initial release.</release>
    </releases>


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/2

Add `cpackget pack list` command. Here are a few examples:

* List all packs installed
```bash
$ ./build/cpackget pack list
I: Using pack root: ".cpackget/"
I: Listing installed packs
I: AnalogDevices.CM41x_M0_DFP.1.0.0
I: ARM.mbedClient.1.1.0
I: ARM.minar.1.0.0
```

* List all cached packs
```bash
$ ./build/cpackget pack list --cached
I: Using pack root: ".cpackget/"
I: Listing cached packs
I: AnalogDevices.CM41x_M0_DFP.1.0.0 (installed)
I: ARM.mbedClient.1.1.0 (installed)
I: ARM.minar.1.0.0 (installed)
I: Keil.MDK-Middleware.7.11.1
I: wolfSSL.wolfSSL.5.0.0

# Remove one of the cached packs
$ ./build/cpackget pack rm --purge wolfSSL.wolfSSL.5.0.0
I: Using pack root: ".cpackget/"
I: Removing [wolfSSL.wolfSSL.5.0.0]

# List again to confirm it's not listed
$ ./build/cpackget pack list --cached
I: Using pack root: ".cpackget/"
I: Listing cached packs
I: AnalogDevices.CM41x_M0_DFP.1.0.0 (installed)
I: ARM.mbedClient.1.1.0 (installed)
I: ARM.minar.1.0.0 (installed)
I: Keil.MDK-Middleware.7.11.1
```

* List all packs available in the public index
```bash
$ ./build/cpackget pack list --public
I: Using pack root: ".cpackget/"
I: Listing installed packs
I: AnalogDevices.CM41x_M0_DFP.1.0.0 (installed)
I: ARM.mbedClient.1.1.0 (cached)
I: ARM.minar.1.0.0 # not installed nor cached
```