### PR TITLE
installer: normalize paths

### DIFF
--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -36,6 +36,7 @@ var (
 	ErrExtractEula           = errors.New("user wants to extract embedded license only")
 	ErrLicenseNotFound       = errors.New("embedded license not found")
 	ErrPackRootNotFound      = errors.New("no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option -R/--pack-root string")
+	ErrPackRootDoesNotExist  = errors.New("the specified CMSIS Pack Root directory does NOT exist! Please take a moment to review if the value is correct or create a new one via `cpackget init` command")
 	ErrPdscFileTooDeepInPack = errors.New("pdsc file is too deep in pack file")
 
 	// Errors related to network

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -247,6 +247,7 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 			return strings.ToLower(matches[i]) < strings.ToLower(matches[j])
 		})
 		for _, pdscFilePath := range matches {
+			log.Debug(pdscFilePath)
 
 			// Transform pdscFilePath into packName
 			pdscFilePath = strings.Replace(pdscFilePath, Installation.PackRoot, "", -1)
@@ -344,10 +345,16 @@ var Installation *PacksInstallationType
 // SetPackRoot sets the working directory of the packs installation
 // if create == true, cpackget will try to create needed resources
 func SetPackRoot(packRoot string, create bool) error {
+	if len(packRoot) == 0 {
+		log.Infof("Using pack root: \"%v\"", packRoot)
+		return errs.ErrPackRootNotFound
+	}
+
+	packRoot = filepath.Clean(packRoot)
 	log.Infof("Using pack root: \"%v\"", packRoot)
 
-	if len(packRoot) == 0 || (!utils.DirExists(packRoot) && !create) {
-		return errs.ErrPackRootNotFound
+	if !utils.DirExists(packRoot) && !create {
+		return errs.ErrPackRootDoesNotExist
 	}
 
 	Installation = &PacksInstallationType{

--- a/cmd/installer/root_unix_test.go
+++ b/cmd/installer/root_unix_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+// +build !windows
+
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package installer_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func generatePaths(t *testing.T) map[string]string {
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+
+	dirName := "valid-pack-root"
+	absPath := filepath.Join(cwd, dirName)
+
+	// Define a few paths to try out
+	return map[string]string{
+		"regular absolute path":     absPath,
+		"absolute path with ..":     filepath.Join(absPath, "..", dirName),
+		"multiple leading slashes":  "////" + absPath,
+		"multiple trailing slashes": absPath + "////",
+	}
+}

--- a/cmd/installer/root_windows_test.go
+++ b/cmd/installer/root_windows_test.go
@@ -1,0 +1,34 @@
+//go:build windows
+// +build windows
+
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package installer_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func generatePaths(t *testing.T) map[string]string {
+	cwd, err := os.Getwd()
+	assert.Nil(t, err)
+
+	dirName := "valid-pack-root"
+	absPath := filepath.Join(cwd, dirName)
+
+	// Define a few paths to try out
+	return map[string]string{
+		"regular absolute path":     absPath,
+		"absolute path with ..":     filepath.Join(absPath, "..", dirName),
+		"absolute path with :/":     strings.Replace(absPath, ":\\", "/", 1),
+		"all forward slashes":       strings.ReplaceAll(absPath, "\\", "/"),
+		"multiple leading slashes":  strings.Replace(absPath, ":\\", ":\\\\\\\\", 1),
+		"multiple trailing slashes": absPath + "\\\\\\\\",
+	}
+}


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/36

By default, `CMSIS_PACK_ROOT` environment variable is defined in a Windows environment as `C:\SOME_PATH`. Both bash and cmd work fine with that approach.

In git-bash/mingw, if the user tries to `export CMSIS_PACK_ROOT=C:\SOME_PATH` or `--pack-root/-R C:\SOME_PATH`, bash automatically removes the backwards slash `\` because it is considered to be a escape character, so it becomes `C:SOME_PATH`, which is a valid directory name. It's wrong, but valid.

I wrongly assumed that this would throw an error when cpackget tried to check if it existed. The colon `:` character is [not allowed](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#naming-conventions) in directory names on Windows. But in reality, that does not fail in neither bash nor cmd:
* in bash, this becomes a valid name `C:SOME_PATH` which Windows later translates it to the unicode character [61498](https://wutils.com/unicode/61498) which is valid.
* in cmd, this becomes `SOME_PATH` (`C:` is removed) only, which is still valid.

To fix that, users should either escape all backwards slashes `C:\\SOME_PATH\\SUB_DIR`or wrap it around single/double quotes `cpackget -R "C:\SOME_PATH"`.

Another finding is that bash paths formatted as `/c/SOME_PATH` are always translated to `C:/SOME_PATH` with the forward slash before passing it to cpackget. And this is where things get confusing, because when cpackget lists installed packs, and they all start with `C:\SOME_PATH`. This means that cpackget will never receive paths in `/c/SOME_PATH` format. It seems this is just a visualization feature of bash.

By using the correct approach to set the path, cpackget works just fine.

So I created this patch to fix cases where paths like `C:/SOME_PATH` are sent to cpackget. The following paths are now cleared before being used by cpackget:
* `C:/SOME-PATH` becomes `C:\SOME_PATH`
* `C:////SOME_PATH` becomes `C:\SOME_PATH`
* `C:\\\\SOME_PATH` becomes `C:\SOME_PATH`
* `C:/SOME_PATH\SUBDIR` becomes `C:\SOME_PATH\SUBDIR`, and so on