### PR TITLE
Purge possible license files

### DIFF
--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -223,13 +223,14 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 	}
 
 	packHomeDir := filepath.Join(Installation.PackRoot, p.Vendor, p.Name, p.GetVersion())
+	packBackupPath := filepath.Join(Installation.DownloadDir, p.PackFileName())
 
 	if len(p.Pdsc.License) > 0 {
 		if checkEula {
 			ok, err := p.checkEula()
 			if err != nil {
 				if err == errs.ErrExtractEula {
-					return p.extractEula()
+					return p.extractEula(packBackupPath)
 				}
 				return err
 			}
@@ -284,7 +285,6 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(Installation.DownloadDir, newPdscFileName))
 
-	packBackupPath := filepath.Join(Installation.DownloadDir, p.PackFileName())
 	if !p.isDownloaded {
 		return utils.CopyFile(p.path, packBackupPath)
 	}
@@ -393,7 +393,7 @@ func (p *PackType) checkEula() (bool, error) {
 }
 
 // extractEula extracts the pack's License to a file next to the pack's location
-func (p *PackType) extractEula() error {
+func (p *PackType) extractEula(packPath string) error {
 	log.Debug("Extracting EULA")
 
 	eulaContents, err := p.readEula()
@@ -401,7 +401,7 @@ func (p *PackType) extractEula() error {
 		return err
 	}
 
-	eulaFileName := p.path + "." + path.Base(p.Pdsc.License)
+	eulaFileName := packPath + "." + path.Base(p.Pdsc.License)
 
 	log.Infof("Extracting embedded license to %v", eulaFileName)
 

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -373,7 +373,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := packWithLicense
 
-		extractedLicensePath := packPath + ".LICENSE.txt"
+		extractedLicensePath := filepath.Join(installer.Installation.DownloadDir, filepath.Base(packPath)+".LICENSE.txt")
 
 		ui.LicenseAgreed = nil
 		addPack(t, packPath, ConfigType{


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/1

Ensures that extracted licenses are purged along with other cached pack files.