### PR TITLE
List missing directories in pack-root folder

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -372,18 +372,24 @@ func SetPackRoot(packRoot string, create bool) error {
 	Installation.PublicIndex = filepath.Join(Installation.WebDir, "index.pidx")
 	Installation.PublicIndexXML = xml.NewPidxXML(Installation.PublicIndex)
 
+	missingDirs := []string{}
 	for _, dir := range []string{packRoot, Installation.DownloadDir, Installation.LocalDir, Installation.WebDir} {
 		log.Debugf("Making sure \"%v\" exists", dir)
 		exists := utils.DirExists(dir)
 		if !exists {
 			if !create {
-				return errs.ErrDirectoryNotFound
+				missingDirs = append(missingDirs, dir)
 			} else {
 				if err := utils.EnsureDir(dir); err != nil {
 					return err
 				}
 			}
 		}
+	}
+
+	if len(missingDirs) > 0 {
+		log.Errorf("Directory(ies) \"%s\" are missing! Was %s initialized correctly?", strings.Join(missingDirs[:], ", "), packRoot)
+		return errs.ErrAlreadyLogged
 	}
 
 	// Make sure utils.DownloadFile always downloads files to .Download/


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/49

By default, cpackget does a quick [sanity check](https://github.com/Open-CMSIS-Pack/cpackget/blob/v0.3.2/cmd/installer/root.go#L371) on the pack-root folder before most of its work. When any of the meaningful directories are missing, cpackget would only raise an error "directory not found".

This patch improves this by listing all missing directories. Here's an example:

```
$ cpackget --pack-root /tmp/new-pack-root init https://www.keil.com/pack/index.pidx

# Remove .Web and .Download
$ rm -rf /tmp/new-pack-root/.{Web,Download}

$ cpackget --pack-root /tmp/new-pack-root/ index https://www.keil.com/pack/index.pidx
I: Using pack root: "/tmp/new-pack-root"
E: Directory(ies) "/tmp/new-pack-root/.Download, /tmp/new-pack-root/.Web" are missing! Was /tmp/new-pack-root initialized correctly?
```