### PR TITLE
make: Default to building for the host

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,7 @@
-# Having these will allow CI scripts to build for many OS's and ARCH's
-OS   := $(or $(OS),$(OS),linux)
+# Default to building for the host
+OS ?= $(shell uname)
+
+# Having this will allow CI scripts to build for many OS's and ARCH's
 ARCH := $(or $(ARCH),$(ARCH),amd64)
 
 # Path to lint tool
@@ -12,6 +14,11 @@ PROG := build/$(BIN_NAME)
 ifneq (,$(findstring indows,$(OS)))
     PROG=build/$(BIN_NAME).exe
     OS=windows
+else ifneq (,$(findstring Darwin,$(OS)))
+    OS=darwin
+else
+    # Default to Linux
+    OS=linux
 endif
 
 SOURCES := $(wildcard cmd/*.go) $(wildcard cmd/*/*.go)


### PR DESCRIPTION
If $OS is not set when running make, the Makefile currently defaults to
building for "linux", not the current host OS. Call out to uname to
determine the OS to use instead, so we can pick a default value for OS
based on the host system. This fixes auto-detection of the OS on macOS.

On Windows, %OS% is already set as an environment variable and we'll
skip calling uname, which is likely not available on Windows.

Fixes #51