### PR TITLE
installer: do not raise error when installing a pack already installed

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -30,8 +30,8 @@ func AddPack(packPath string, checkEula, extractEula bool) error {
 	log.Infof("Adding pack \"%s\"", packPath)
 
 	if !extractEula && pack.isInstalled {
-		log.Errorf("pack %s is already installed here: %s", packPath, filepath.Join(Installation.PackRoot, pack.Vendor, pack.Name, pack.GetVersion()))
-		return errs.ErrAlreadyLogged
+		log.Infof("pack %s is already installed here: %s", packPath, filepath.Join(Installation.PackRoot, pack.Vendor, pack.Name, pack.GetVersion()))
+		return nil
 	}
 
 	if pack.isPackID {

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -67,11 +67,10 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 		packIdxModTime := packIdx.ModTime()
 
-		// Attempt installing it again, this time we should get an error
+		// Attempt installing it again, this time it should noop
 		packPath = publicLocalPack123
 		err = installer.AddPack(packPath, !CheckEula, !ExtractEula)
-		assert.NotNil(err)
-		assert.Equal(err, errs.ErrAlreadyLogged)
+		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
 		packIdx, err = os.Stat(installer.Installation.PackIdx)
@@ -777,8 +776,7 @@ func TestAddPack(t *testing.T) {
 		packIdxModTime := packIdx.ModTime()
 
 		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula)
-		assert.NotNil(err)
-		assert.Equal(errs.ErrAlreadyLogged, err)
+		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
 		packIdx, err = os.Stat(installer.Installation.PackIdx)
@@ -1031,8 +1029,7 @@ func TestAddPack(t *testing.T) {
 		packIdxModTime := packIdx.ModTime()
 
 		err = installer.AddPack(publicLocalPack011WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula)
-		assert.NotNil(err)
-		assert.Equal(errs.ErrAlreadyLogged, err)
+		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
 		packIdx, err = os.Stat(installer.Installation.PackIdx)
@@ -1152,8 +1149,7 @@ func TestAddPack(t *testing.T) {
 		packIdxModTime := packIdx.ModTime()
 
 		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula)
-		assert.NotNil(err)
-		assert.Equal(errs.ErrAlreadyLogged, err)
+		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
 		packIdx, err = os.Stat(installer.Installation.PackIdx)
@@ -1226,8 +1222,7 @@ func TestAddPack(t *testing.T) {
 		packIdxModTime := packIdx.ModTime()
 
 		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula)
-		assert.NotNil(err)
-		assert.Equal(errs.ErrAlreadyLogged, err)
+		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
 		packIdx, err = os.Stat(installer.Installation.PackIdx)


### PR DESCRIPTION
Half-fix https://github.com/Open-CMSIS-Pack/cpackget/issues/58

Change the message `E: pack ARM.CMSIS.5.8.0 is already installed here: .packs\ARM\CMSIS\5.8.0` to info and do not return an error.