### PR TITLE
Find url for older packs

### DIFF
--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -66,7 +66,7 @@ var (
 	ErrPackPdscCannotBeFound           = errors.New("the URL for the pack pdsc file seems not to exist or it didn't return the file")
 	ErrPackVersionNotFoundInPdsc       = errors.New("pack version not found in the pdsc file")
 	ErrPackVersionNotLatestReleasePdsc = errors.New("pack version is not the latest in the pdsc file")
-	ErrPackURLCannotBeFound            = errors.New("URL for the pack cannot be determined. Please consider updating the public index. Ex: cpackget --force index https://keil.com/pack/index.pidx")
+	ErrPackURLCannotBeFound            = errors.New("URL for the pack cannot be determined. Please consider updating the public index. Ex: cpackget index --force https://keil.com/pack/index.pidx")
 
 	// Hack to allow multiple error logs while still avoiding duplicating the last error log
 	ErrAlreadyLogged = errors.New("already logged")

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -552,7 +552,8 @@ func (p *PacksInstallationType) packIsPublic(pack *PackType) (bool, error) {
 	log.Debugf("Not found \"%s\" in \"%s\"", pack.PdscFileName(), p.WebDir)
 
 	// Try to retrieve the packs's PDSC file out of the index.pidx
-	pdscTag := p.PublicIndexXML.FindPdscTag(pack.PdscTag)
+	searchPdscTag := xml.PdscTag{Vendor: pack.Vendor, Name: pack.Name}
+	pdscTag := p.PublicIndexXML.FindPdscTag(searchPdscTag)
 	if pdscTag == nil {
 		log.Debugf("Not found \"%s\" tag in \"%s\"", pack.PdscFileName(), p.PublicIndex)
 		return false, nil


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/57

@JonatanAntoni, this works now

```
$ cpackget -R .packs init https://keil.com/pack/index.pidx
    
$ cpackget -R .packs pack add ARM.V2M_MPS3_SSE_300_BSP.1.2.0
I: Using pack root: ".packs"
I: Downloading ARM.V2M_MPS3_SSE_300_BSP.pdsc 100% | (25/25 kB, 123.804 kB/s)        
I: Adding pack "ARM.V2M_MPS3_SSE_300_BSP.1.2.0"
I: Downloading ARM.V2M_MPS3_SSE_300_BSP.1.2.0.pack 100% | (5.3/5.3 MB, 37.052 MB/s)        
I: Extracting files to .packs/ARM/V2M_MPS3_SSE_300_BSP/1.2.0 100% | (102/102, 1193 it/s)
```