### PR TITLE
Do not display progressbar on non-interactive terminals

### DIFF
--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -271,9 +271,18 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 	}
 
 	log.Debugf("Extracting files from \"%s\" to \"%s\"", p.path, packHomeDir)
-	progress := progressbar.Default(int64(len(p.zipReader.File)), "I: Extracting files to "+packHomeDir)
+
+	var progress *progressbar.ProgressBar
+	if utils.IsTerminalInteractive() {
+		progress = progressbar.Default(int64(len(p.zipReader.File)), "I: Extracting files to "+packHomeDir)
+	} else {
+		log.Infof("Extracting files to %s...", packHomeDir)
+	}
+
 	for _, file := range p.zipReader.File {
-		_ = progress.Add(1)
+		if utils.IsTerminalInteractive() {
+			_ = progress.Add(1)
+		}
 		err = utils.SecureInflateFile(file, packHomeDir, p.Subfolder)
 		if err != nil {
 			defer p.zipReader.Close()

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -62,11 +62,14 @@ func DownloadFile(URL string) (string, error) {
 
 	writers := []io.Writer{out}
 	if log.GetLevel() != log.ErrorLevel {
-		progressWriter := progressbar.DefaultBytes(
-			resp.ContentLength,
-			"I: Downloading "+fileBase,
-		)
-		writers = append(writers, progressWriter)
+		if IsTerminalInteractive() {
+			length := resp.ContentLength
+			message := "I: Downloading " + fileBase
+			progressWriter := progressbar.DefaultBytes(length, message)
+			writers = append(writers, progressWriter)
+		} else {
+			log.Infof("Downloading %s...", fileBase)
+		}
 	}
 
 	// Download file in smaller bits straight to a local file


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/52

Cpackget will detect if running on a non-interactive terminal and avoid the use of a progress bar. Sample output:
```
I: Using pack root: "test-add-public-remote-pack"
I: Adding pack "https://127.0.0.1:63540/TheVendor.PublicRemotePack.1.2.3.pack"
I: Downloading TheVendor.PublicRemotePack.1.2.3.pack...
I: Extracting files to test-add-public-remote-pack\TheVendor\PublicRemotePack\1.2.3...
```