### PR TITLE
installer: pdsc: do not raise error installing packs already installed

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -99,6 +99,10 @@ func AddPdsc(pdscPath string) error {
 	}
 
 	if err := pdsc.install(Installation); err != nil {
+		if err == errs.ErrPdscEntryExists {
+			log.Info(err)
+			return nil
+		}
 		return err
 	}
 

--- a/cmd/installer/root_pdsc_add_test.go
+++ b/cmd/installer/root_pdsc_add_test.go
@@ -58,7 +58,7 @@ func TestAddPdsc(t *testing.T) {
 		assert.Nil(err)
 
 		err = installer.AddPdsc(pdscPack123)
-		assert.Equal(errs.ErrPdscEntryExists, err)
+		assert.Nil(err)
 	})
 
 	t.Run("test add new pdsc version", func(t *testing.T) {


### PR DESCRIPTION
Addresses https://github.com/Open-CMSIS-Pack/cpackget/pull/59#issuecomment-1113261403

Replicating the same behavior for `pack add`, avoid raising an error when installing a PDSC file that is already present.