### PR TITLE
Print copyright instead of license summary

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/open-cmsis-pack/cpackget/cmd/commands"
 	"github.com/spf13/cobra"
@@ -18,8 +19,7 @@ var flags struct {
 }
 
 func printVersionAndLicense(file io.Writer) {
-	fmt.Fprintf(file, "cpackget version %v\n", version)
-	fmt.Fprintf(file, "%v\n", license)
+	fmt.Fprintf(file, "cpackget version %v %s\n", strings.ReplaceAll(version, "v", ""), copyRight)
 }
 
 // UsageTemplate returns usage template for the command.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,16 +5,4 @@ package main
 
 var version string
 
-const license = `Copyright 2022 Linaro
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.`
+const copyRight = "(C) 2022 Linaro"


### PR DESCRIPTION
Addresses https://github.com/Open-CMSIS-Pack/cpackget/issues/35#issuecomment-1114818856

```bash
$ cpackget --version
cpackget version v0.4.1 (C) 2022 Linaro
```
