### PR TITLE
Do not create file on HTTP error during download

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -41,13 +41,6 @@ func DownloadFile(URL string) (string, error) {
 		return filePath, nil
 	}
 
-	out, err := os.Create(filePath)
-	if err != nil {
-		log.Error(err)
-		return "", errs.ErrFailedCreatingFile
-	}
-	defer out.Close()
-
 	resp, err := HTTPClient.Get(URL) // #nosec
 	if err != nil {
 		log.Error(err)
@@ -59,6 +52,13 @@ func DownloadFile(URL string) (string, error) {
 		log.Errorf("bad status: %s", resp.Status)
 		return "", errs.ErrBadRequest
 	}
+
+	out, err := os.Create(filePath)
+	if err != nil {
+		log.Error(err)
+		return "", errs.ErrFailedCreatingFile
+	}
+	defer out.Close()
 
 	writers := []io.Writer{out}
 	if log.GetLevel() != log.ErrorLevel {


### PR DESCRIPTION
Fix part of https://github.com/Open-CMSIS-Pack/cpackget/issues/68

When cpackget downloads a file, it creates the destination file before even making an HTTP connection. So if the connection fails for some reason, the file gets created and wrongly used the next time a new download is attempted.

This patch makes sure to create the destination file for downloads only after all HTTP connection is successful.