### PR TITLE
installed: list commands using Yaml naming standard

### DIFF
--- a/cmd/commands/list_test.go
+++ b/cmd/commands/list_test.go
@@ -17,7 +17,7 @@ var listCmdTests = []TestCase{
 		name:           "test listing installed packs",
 		args:           []string{"list"},
 		createPackRoot: true,
-		expectedStdout: []string{"Vendor.Pack.1.2.3", "Vendor.PackInstalledViaPdsc.1.2.3"},
+		expectedStdout: []string{"Vendor::Pack@1.2.3", "Vendor::PackInstalledViaPdsc@1.2.3"},
 		setUpFunc: func(t *TestCase) {
 			packRoot := os.Getenv("CMSIS_PACK_ROOT")
 			packFolder := filepath.Join(packRoot, "Vendor", "Pack", "1.2.3")

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -190,7 +190,7 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 		// List all available packs from the index
 		for _, pdscKey := range keys {
 			pdscTag := pdscMap[pdscKey]
-			logMessage := pdscKey
+			logMessage := pdscTag.YamlPackID()
 			packFilePath := filepath.Join(Installation.DownloadDir, pdscTag.Key()) + ".pack"
 
 			if Installation.PackIsInstalled(&PackType{PdscTag: pdscTag}) {
@@ -217,6 +217,7 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 			return strings.ToLower(matches[i]) < strings.ToLower(matches[j])
 		})
 		for _, packFilePath := range matches {
+			packFilePath = strings.ReplaceAll(packFilePath, ".pack", "")
 			packInfo, err := utils.ExtractPackInfo(packFilePath)
 			if err != nil {
 				log.Errorf("A pack in the cache folder has malformed pack name: %s", packFilePath)
@@ -229,7 +230,7 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 				Version: packInfo.Version,
 			}
 
-			logMessage := pdscTag.Key()
+			logMessage := pdscTag.YamlPackID()
 			if Installation.PackIsInstalled(&PackType{PdscTag: pdscTag}) {
 				logMessage += " (installed)"
 			}
@@ -321,7 +322,7 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 				errors = append(errors, "pack version")
 			}
 
-			message := pack.Key()
+			message := pack.YamlPackID()
 
 			// Print the PDSC path on packs installed via PDSC file
 			if pack.isPdscInstalled {

--- a/cmd/installer/root_pack_list_test.go
+++ b/cmd/installer/root_pack_list_test.go
@@ -102,9 +102,9 @@ func ExampleListInstalledPacks_list() {
 	_ = installer.ListInstalledPacks(ListCached, ListPublic)
 	// Output:
 	// I: Listing packs from the public index
-	// I: TheVendor.PublicLocalPack.1.2.3 (cached)
-	// I: TheVendor.PublicLocalPack.1.2.4 (installed)
-	// I: TheVendor.PublicLocalPack.1.2.5
+	// I: TheVendor::PublicLocalPack@1.2.3 (cached)
+	// I: TheVendor::PublicLocalPack@1.2.4 (installed)
+	// I: TheVendor::PublicLocalPack@1.2.5
 }
 
 func ExampleListInstalledPacks_listCached() {
@@ -138,8 +138,8 @@ func ExampleListInstalledPacks_listCached() {
 	_ = installer.ListInstalledPacks(ListCached, !ListPublic)
 	// Output:
 	// I: Listing cached packs
-	// I: TheVendor.PublicLocalPack.1.2.3
-	// I: TheVendor.PublicLocalPack.1.2.4 (installed)
+	// I: TheVendor::PublicLocalPack@1.2.3
+	// I: TheVendor::PublicLocalPack@1.2.4 (installed)
 }
 
 func TestListInstalledPacks(t *testing.T) {
@@ -184,8 +184,8 @@ func TestListInstalledPacks(t *testing.T) {
 		assert.Nil(installer.ListInstalledPacks(!ListCached, !ListPublic))
 		stdout := buf.String()
 		assert.Contains(stdout, "I: Listing installed packs")
-		assert.Contains(stdout, fmt.Sprintf("I: TheVendor.PackName.1.2.3 (installed via %s)", expectedPdscAbsPath))
-		assert.Contains(stdout, "I: TheVendor.PublicLocalPack.1.2.4")
+		assert.Contains(stdout, fmt.Sprintf("I: TheVendor::PackName@1.2.3 (installed via %s)", expectedPdscAbsPath))
+		assert.Contains(stdout, "I: TheVendor::PublicLocalPack@1.2.4")
 	})
 
 	t.Run("test listing local packs with updated version", func(t *testing.T) {
@@ -213,7 +213,7 @@ func TestListInstalledPacks(t *testing.T) {
 		assert.Nil(installer.ListInstalledPacks(!ListCached, !ListPublic))
 		stdout := buf.String()
 		assert.Contains(stdout, "I: Listing installed packs")
-		assert.Contains(stdout, fmt.Sprintf("I: TheVendor.PackName.1.2.3 (installed via %s)", expectedPdscAbsPath))
+		assert.Contains(stdout, fmt.Sprintf("I: TheVendor::PackName@1.2.3 (installed via %s)", expectedPdscAbsPath))
 
 		// Now update the version inside the PDSC file and expect it to be listed
 		pdscXML := xml.NewPdscXML(pdscPath)
@@ -223,7 +223,7 @@ func TestListInstalledPacks(t *testing.T) {
 		assert.Nil(installer.ListInstalledPacks(!ListCached, !ListPublic))
 		stdout = buf.String()
 		assert.Contains(stdout, "I: Listing installed packs")
-		assert.Contains(stdout, fmt.Sprintf("I: TheVendor.PackName.1.2.4 (installed via %s)", expectedPdscAbsPath))
+		assert.Contains(stdout, fmt.Sprintf("I: TheVendor::PackName@1.2.4 (installed via %s)", expectedPdscAbsPath))
 	})
 }
 
@@ -260,6 +260,6 @@ func ExampleListInstalledPacks_listMalformedInstalledPacks() {
 	_ = installer.ListInstalledPacks(!ListCached, !ListPublic)
 	// Output:
 	// I: Listing installed packs
-	// E: _TheVendor._PublicLocalPack.1.2.3.4 - error: vendor, pack name, pack version incorrect format
+	// E: _TheVendor::_PublicLocalPack@1.2.3.4 - error: vendor, pack name, pack version incorrect format
 	// W: 1 error(s) detected
 }

--- a/cmd/xml/pidx.go
+++ b/cmd/xml/pidx.go
@@ -175,6 +175,12 @@ func (p *PdscTag) Key() string {
 	return p.Vendor + "." + p.Name + "." + p.Version
 }
 
+// YamlPackId formats the packId as specified in
+// https://github.com/Open-CMSIS-Pack/devtools/blob/tools/toolbox/0.10.0/tools/projmgr/docs/Manual/YML-Format.md#pack-name-conventions
+func (p *PdscTag) YamlPackID() string {
+	return p.Vendor + "::" + p.Name + "@" + p.Version
+}
+
 // PackURL constructs a URL of a pack using the tag's attributes.
 func (p *PdscTag) PackURL() string {
 	return p.URL + p.Key() + ".pack"

--- a/cmd/xml/pidx_test.go
+++ b/cmd/xml/pidx_test.go
@@ -27,6 +27,17 @@ func TestPdscTag(t *testing.T) {
 
 		assert.Equal(pdscTag.Key(), "TheVendor.ThePack.0.0.1")
 	})
+
+	t.Run("test PdscTag YamlPackID", func(t *testing.T) {
+		pdscTag := xml.PdscTag{
+			Vendor:  "TheVendor",
+			Name:    "ThePack",
+			Version: "0.0.1",
+			URL:     "http://vendor.com/",
+		}
+
+		assert.Equal(pdscTag.YamlPackID(), "TheVendor::ThePack@0.0.1")
+	})
 }
 
 func TestPidxXML(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/71

List packs as "ARM::CMSIS@5.7.0" instead of "ARM.CMSIS.5.7.0". Ex:
```bash
$ cpackget list 
I: Using pack root: "../packroot"
I: Listing installed packs
I: ARM::CMSIS@4.3.0
I: ARM::CMSIS@4.4.0
I: ARM::CMSIS@5.7.0
I: ARM::CMSIS@5.8.0
I: AWS::coreHTTP@2.0.0-Beta
I: TheVendor::DevPack@1.2.3 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.3/TheVendor.DevPack.pdsc)
```