### PR TITLE
Remove pdsc using file path

### DIFF
--- a/cmd/commands/add_test.go
+++ b/cmd/commands/add_test.go
@@ -23,7 +23,7 @@ var addCmdTests = []TestCase{
 		name:           "test adding pack missing file",
 		args:           []string{"add", "DoesNotExist.Pack.1.2.3.pack"},
 		createPackRoot: true,
-		expectedStdout: []string{"File \\\"DoesNotExist.Pack.1.2.3.pack\\\" does't exist"},
+		expectedStdout: []string{"File", "DoesNotExist.Pack.1.2.3.pack", "does't exist"},
 		expectedErr:    errs.ErrFileNotFound,
 	},
 	{

--- a/cmd/commands/pack_test.go
+++ b/cmd/commands/pack_test.go
@@ -36,7 +36,7 @@ var packCmdTests = []TestCase{
 		name:           "test adding pack missing file",
 		args:           []string{"pack", "add", "DoesNotExist.Pack.1.2.3.pack"},
 		createPackRoot: true,
-		expectedStdout: []string{"File \\\"DoesNotExist.Pack.1.2.3.pack\\\" does't exist"},
+		expectedStdout: []string{"File", "DoesNotExist.Pack.1.2.3.pack", "does't exist"},
 		expectedErr:    errs.ErrAlreadyLogged,
 	},
 	{

--- a/cmd/commands/rm_test.go
+++ b/cmd/commands/rm_test.go
@@ -25,14 +25,14 @@ var rmCmdTests = []TestCase{
 		name:           "test removing pack that does not exist",
 		args:           []string{"rm", "DoesNotExist.Pack.1.2.3"},
 		createPackRoot: true,
-		expectedStdout: []string{"Removing [DoesNotExist.Pack.1.2.3]"},
-		expectedErr:    errs.ErrPackNotInstalled,
+		expectedStdout: []string{"Removing [DoesNotExist.Pack.1.2.3]", "pack not installed"},
+		expectedErr:    errs.ErrAlreadyLogged,
 	},
 	{
 		name:           "test removing pack",
-		args:           []string{"rm", "Vendor.Pack.1.2.3", "Vendor.PackInstalledViaPdsc.1.2.3"},
+		args:           []string{"rm", "Vendor.Pack.1.2.3", "Vendor.PackInstalledViaPdsc.pdsc"},
 		createPackRoot: true,
-		expectedStdout: []string{"Removing [Vendor.Pack.1.2.3 Vendor.PackInstalledViaPdsc.1.2.3]"},
+		expectedStdout: []string{"Removing [Vendor.Pack.1.2.3 Vendor.PackInstalledViaPdsc.pdsc]"},
 		setUpFunc: func(t *TestCase) {
 			packRoot := os.Getenv("CMSIS_PACK_ROOT")
 			packFolder := filepath.Join(packRoot, "Vendor", "Pack", "1.2.3")

--- a/cmd/commands/root_test.go
+++ b/cmd/commands/root_test.go
@@ -6,6 +6,7 @@ package commands_test
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -17,8 +18,18 @@ import (
 
 	"github.com/open-cmsis-pack/cpackget/cmd/commands"
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+// Copy of cmd/log.go
+type LogFormatter struct{}
+
+func (s *LogFormatter) Format(entry *log.Entry) ([]byte, error) {
+	level := strings.ToUpper(entry.Level.String())
+	msg := fmt.Sprintf("%s: %s\n", level[0:1], entry.Message)
+	return []byte(msg), nil
+}
 
 var testingDir = filepath.Join("..", "..", "testdata", "integration")
 
@@ -176,4 +187,13 @@ func runTests(t *testing.T, tests []TestCase) {
 
 func TestRootCmd(t *testing.T) {
 	runTests(t, rootCmdTests)
+}
+
+func init() {
+	logLevel := log.InfoLevel
+	if os.Getenv("LOG_LEVEL") == "debug" {
+		logLevel = log.DebugLevel
+	}
+	log.SetLevel(logLevel)
+	log.SetFormatter(new(LogFormatter))
 }

--- a/cmd/installer/pdsc.go
+++ b/cmd/installer/pdsc.go
@@ -80,6 +80,19 @@ func (p *PdscType) install(installation *PacksInstallationType) error {
 		return err
 	}
 
+	searchTag := xml.PdscTag{
+		Vendor: tag.Vendor,
+		Name:   tag.Name,
+	}
+	foundTags := installation.LocalPidx.FindPdscTags(searchTag)
+	if len(foundTags) > 0 {
+		for _, foundTag := range foundTags {
+			if foundTag.URL == tag.URL {
+				return errs.ErrPdscEntryExists
+			}
+		}
+	}
+
 	return Installation.LocalPidx.AddPdsc(tag)
 }
 

--- a/cmd/installer/pdsc.go
+++ b/cmd/installer/pdsc.go
@@ -4,6 +4,10 @@
 package installer
 
 import (
+	"path/filepath"
+	"strings"
+
+	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/open-cmsis-pack/cpackget/cmd/utils"
 	"github.com/open-cmsis-pack/cpackget/cmd/xml"
 	log "github.com/sirupsen/logrus"
@@ -85,5 +89,38 @@ func (p *PdscType) install(installation *PacksInstallationType) error {
 //     If version is ommited, remove all pdsc tags belonging to this pack
 func (p *PdscType) uninstall(installation *PacksInstallationType) error {
 	log.Debugf("Unistalling \"%s\"", p.path)
-	return Installation.LocalPidx.RemovePdsc(p.PdscTag)
+
+	tags := installation.LocalPidx.FindPdscTags(xml.PdscTag{
+		Vendor: p.Vendor,
+		Name:   p.Name,
+	})
+
+	if len(tags) == 0 {
+		return errs.ErrPdscEntryNotFound
+	}
+
+	toRemove := []xml.PdscTag{}
+	dirName := filepath.Dir(p.path)
+	if dirName == "" || dirName == "." {
+		toRemove = tags
+	} else {
+		targetPath := strings.ReplaceAll(dirName, "\\", "/")
+		for _, tag := range tags {
+			tagURL := strings.ReplaceAll(tag.URL, "\\", "/")
+			if strings.Contains(tagURL, targetPath) {
+				toRemove = append(toRemove, tag)
+			}
+		}
+	}
+
+	if len(toRemove) == 0 {
+		return errs.ErrPdscEntryNotFound
+	}
+
+	for _, tag := range toRemove {
+		if err := installation.LocalPidx.RemovePdsc(tag); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -123,6 +123,10 @@ func RemovePdsc(pdscPath string) error {
 		return err
 	}
 
+	// preparePdsc will fill in the full path for this PDSC file path
+	// in the URL field, that is not needed for removing
+	pdsc.URL = ""
+
 	if err = pdsc.uninstall(Installation); err != nil {
 		return err
 	}

--- a/cmd/installer/root_pdsc_rm_test.go
+++ b/cmd/installer/root_pdsc_rm_test.go
@@ -5,6 +5,7 @@ package installer_test
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
@@ -35,9 +36,86 @@ func TestRemovePdsc(t *testing.T) {
 		err := installer.AddPdsc(pdscPack123)
 		assert.Nil(err)
 
+		tags := installer.Installation.LocalPidx.ListPdscTags()
+		assert.Equal(1, len(tags))
+
 		// Remove it
 		err = installer.RemovePdsc(shortenPackPath(pdscPack123, true))
 		assert.Nil(err)
+
+		// Make sure there is no tags in local_repository.pidx
+		tags = installer.Installation.LocalPidx.ListPdscTags()
+		assert.Equal(0, len(tags))
+	})
+
+	t.Run("test remove multiple pdscs using basename PDSC file name", func(t *testing.T) {
+		localTestingDir := "test-remove-multiple-pdscs-using-basename-pdsc-file-name"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		// Add it first
+		err := installer.AddPdsc(pdscPack123)
+		assert.Nil(err)
+
+		// Add a new version of the same pack
+		err = installer.AddPdsc(pdscPack124)
+		assert.Nil(err)
+
+		tags := installer.Installation.LocalPidx.ListPdscTags()
+		assert.Equal(2, len(tags))
+
+		// Remove it
+		err = installer.RemovePdsc(shortenPackPath(pdscPack123, true))
+		assert.Nil(err)
+
+		// Make sure there is no tags in local_repository.pidx
+		tags = installer.Installation.LocalPidx.ListPdscTags()
+		assert.Equal(0, len(tags))
+	})
+
+	t.Run("test remove a pdsc using full path", func(t *testing.T) {
+		localTestingDir := "test-remove-pdsc-using-full-path"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		// Add it first
+		err := installer.AddPdsc(pdscPack123)
+		assert.Nil(err)
+
+		tags := installer.Installation.LocalPidx.ListPdscTags()
+		assert.Equal(1, len(tags))
+
+		// Remove it
+		absPath, _ := filepath.Abs(pdscPack123)
+		err = installer.RemovePdsc(absPath)
+		assert.Nil(err)
+
+		// Make sure there is no tags in local_repository.pidx
+		tags = installer.Installation.LocalPidx.ListPdscTags()
+		assert.Equal(0, len(tags))
+	})
+
+	t.Run("test remove one pdsc using full path and leave others untouched", func(t *testing.T) {
+		localTestingDir := "test-remove-one-pdsc-using-full-path-and-leave-others-untouched"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		// Add it first
+		err := installer.AddPdsc(pdscPack123)
+		assert.Nil(err)
+
+		// Add a new version of the same pack
+		err = installer.AddPdsc(pdscPack124)
+		assert.Nil(err)
+
+		// Remove only the first one
+		absPath, _ := filepath.Abs(pdscPack123)
+		err = installer.RemovePdsc(absPath)
+		assert.Nil(err)
+
+		// Make sure 1.2.4 is still present in local_repository.pidx
+		tags := installer.Installation.LocalPidx.ListPdscTags()
+		assert.Greater(len(tags), 0)
 	})
 
 	t.Run("test remove a pdsc that does not exist", func(t *testing.T) {

--- a/cmd/utils/packs.go
+++ b/cmd/utils/packs.go
@@ -218,6 +218,8 @@ func ExtractPackInfo(packPath string) (PackInfo, error) {
 			absPath, _ := os.Getwd()
 			location = filepath.Join(absPath, location)
 			location, _ = filepath.Abs(location)
+		} else {
+			location = filepath.Clean(location)
 		}
 
 		location = "file://localhost/" + location + string(os.PathSeparator)

--- a/cmd/xml/pidx_test.go
+++ b/cmd/xml/pidx_test.go
@@ -87,8 +87,8 @@ func TestPidxXML(t *testing.T) {
 		// Adding a second PDSC tag is OK
 		assert.Nil(pidx.AddPdsc(pdscTag2))
 
-		// Adding a PDSC of a Pack with different URL is NOT OK
-		assert.Equal(pidx.AddPdsc(pdscTag2DiffURL), errs.ErrPdscEntryExists)
+		// Adding a PDSC of a Pack with different URL is also OK
+		assert.Nil(pidx.AddPdsc(pdscTag2DiffURL))
 	})
 
 	t.Run("test removing a PDSC tag from a PIDX file", func(t *testing.T) {
@@ -200,8 +200,8 @@ func TestPidxXML(t *testing.T) {
 		assert.Nil(pidx.Write())
 		newPidx := xml.NewPidxXML(fileName)
 		assert.Nil(newPidx.Read())
-		assert.True(newPidx.HasPdsc(pdscTag1))
-		assert.True(newPidx.HasPdsc(pdscTag2))
+		assert.Greater(newPidx.HasPdsc(pdscTag1), xml.PdscIndexNotFound)
+		assert.Greater(newPidx.HasPdsc(pdscTag2), xml.PdscIndexNotFound)
 	})
 
 	t.Run("test reading PIDX file with malformed XML", func(t *testing.T) {
@@ -235,15 +235,15 @@ func TestPidxXML(t *testing.T) {
 		// Find with empty version
 		assert.Nil(pidx.AddPdsc(pdscTag1))
 		pdscTag1.Version = ""
-		foundTag := pidx.FindPdscTag(pdscTag1)
-		assert.NotNil(foundTag)
-		assert.Equal(foundTag.Version, "0.0.1")
+		foundTags := pidx.FindPdscTags(pdscTag1)
+		assert.Greater(len(foundTags), 0)
+		assert.Equal(foundTags[0].Version, "0.0.1")
 
 		// Find with specified version
 		assert.Nil(pidx.AddPdsc(pdscTag2))
-		foundTag = pidx.FindPdscTag(pdscTag2)
-		assert.NotNil(foundTag)
-		assert.Equal(*foundTag, pdscTag2)
+		foundTags = pidx.FindPdscTags(pdscTag2)
+		assert.Greater(len(foundTags), 0)
+		assert.Equal(foundTags[0], pdscTag2)
 
 	})
 }


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/70 and https://github.com/Open-CMSIS-Pack/cpackget/issues/67

This allows cpackget to remove local packs by using a couple of forms of PDSC file path:
 
```bash   
$ cpackget rm Vendor.Pack.pdsc
$ cpackget rm relativepath/to/Vendor.Pack.pdsc
$ cpackget rm /absolute/path/to/Vendor.Pack.pdsc
```

The first example looks for all PDSC tags in local_repository.pidx with "Vendor" and "Pack" present.
    
The second example is a bit more restrictive. It only removes the PDSC tags that contains "Vendor", "Pack" and that the URL tag attribute contains "path/to". The user might wish to specify the full path of the PDSC file if wanted, as in this third example.

Below is a full example:
```bash
# Add local pack version 1.2.3
$ cpackget add testdata/devpack/1.2.3/TheVendor.DevPack.pdsc 
I: Using pack root: "../packroot"
I: Adding pdsc "testdata/devpack/1.2.3/TheVendor.DevPack.pdsc"

# Add same pack, now version 1.2.4
$ cpackget add testdata/devpack/1.2.4/TheVendor.DevPack.pdsc 
I: Using pack root: "../packroot"
I: Adding pdsc "testdata/devpack/1.2.4/TheVendor.DevPack.pdsc"

# List installed packs
$ cpackget list
I: Using pack root: "../packroot"
I: Listing installed packs
I: TheVendor::DevPack@1.2.3 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.3/TheVendor.DevPack.pdsc)
I: TheVendor::DevPack@1.2.4 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.4/TheVendor.DevPack.pdsc)

# Remove only version 1.2.4 using a path
$ cpackget rm devpack/1.2.4/TheVendor.DevPack.pdsc
I: Using pack root: "../packroot"
I: Removing [devpack/1.2.4/TheVendor.DevPack.pdsc]

# Confirm that only 1.2.4 got removed
$ cpackget list
I: Using pack root: "../packroot"
I: Listing installed packs
I: TheVendor::DevPack@1.2.3 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.3/TheVendor.DevPack.pdsc)

# Re-add 1.2.4
$ cpackget add testdata/devpack/1.2.4/TheVendor.DevPack.pdsc 
I: Using pack root: "../packroot"
I: Adding pdsc "testdata/devpack/1.2.4/TheVendor.DevPack.pdsc"

# Now remove all PDSC tags matching TheVendor.DevPack
$ cpackget rm TheVendor.DevPack.pdsc
I: Using pack root: "../packroot"
I: Removing [TheVendor.DevPack.pdsc]

# Confirm that both packs got removed
$ cpackget list
I: Using pack root: "../packroot"
I: Listing installed packs
I: (no packs installed)
```

By doing the changes in this PR, I went a step further and fixed issue #67:
```bash
# List 1.2.4 installed
$ cpackget list
I: Using pack root: "../packroot"
I: Listing installed packs
I: TheVendor::DevPack@1.2.4 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.4/TheVendor.DevPack.pdsc)

# Copy the PDSC file to a new location so we can edit it
$ cp testdata/devpack/1.2.4/TheVendor.DevPack.pdsc /tmp/

# Update the version to 1.2.5
$ sed -i 's/1.2.4/1.2.5/g' /tmp/TheVendor.DevPack.pdsc

# Installing should be OK
$ cpackget add /tmp/TheVendor.DevPack.pdsc 
I: Using pack root: "../packroot"
I: Adding pdsc "/tmp/TheVendor.DevPack.pdsc"

# Make sure it is installed
$ cpackget list
I: Using pack root: "../packroot"
I: Listing installed packs
I: TheVendor::DevPack@1.2.4 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.4/TheVendor.DevPack.pdsc)
I: TheVendor::DevPack@1.2.5 (installed via /tmp/TheVendor.DevPack.pdsc)

# Now update it to 1.2.6
$ sed -i 's/1.2.5/1.2.6/g' /tmp/TheVendor.DevPack.pdsc 

# Installing should be prevented this time
$ cpackget add /tmp/TheVendor.DevPack.pdsc 
I: Using pack root: "../packroot"
I: Adding pdsc "/tmp/TheVendor.DevPack.pdsc"
I: pdsc already in index

# Make sure it did not get installed, but confirm that the version got updated to 1.2.6
$ cpackget list
I: Using pack root: "../packroot"
I: Listing installed packs
I: TheVendor::DevPack@1.2.4 (installed via /home/chaws/linaro/src/arm/cpackget/testdata/devpack/1.2.4/TheVendor.DevPack.pdsc)
I: TheVendor::DevPack@1.2.6 (installed via /tmp/TheVendor.DevPack.pdsc)
```

This prevents same PDSCs (with different content) from being added to local_repository.pidx.