### PR TITLE
Make index-url mandatory on `cpackget init`

### DIFF
--- a/cmd/commands/index_test.go
+++ b/cmd/commands/index_test.go
@@ -5,6 +5,8 @@ package commands_test
 
 import (
 	"errors"
+	"io/fs"
+	"path/filepath"
 	"testing"
 
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
@@ -54,16 +56,17 @@ func TestIndexCmd(t *testing.T) {
 
 // Tests for init command are placed here because there was something wrong
 // while putting them into a file init_test.go
+
+var (
+	pidxFilePath         = filepath.Join(testingDir, "SamplePublicIndex.pidx")
+	notFoundPidxFilePath = filepath.Join("path", "to", "index.pidx")
+)
+
 var initCmdTests = []TestCase{
 	{
-		name:        "test with no packroot configured",
+		name:        "test no parameter given",
 		args:        []string{"init"},
-		expectedErr: errs.ErrPackRootNotFound,
-	},
-	{
-		name:           "test create with empty index.pidx",
-		args:           []string{"init"},
-		createPackRoot: true,
+		expectedErr: errors.New("accepts 1 arg(s), received 0"),
 	},
 	{
 		name:           "test create using an index.pidx",
@@ -81,6 +84,21 @@ var initCmdTests = []TestCase{
   <pdsc url="http://the.vendor/" vendor="TheVendor" name="PackName" version="1.2.3" />
 </pindex>
 </index>`))
+		},
+	},
+	{
+		name:           "test create using local index.pidx",
+		args:           []string{"init", pidxFilePath},
+		createPackRoot: true,
+	},
+	{
+		name:           "test create using local index.pidx that do not exist",
+		args:           []string{"init", notFoundPidxFilePath},
+		createPackRoot: true,
+		expectedErr: &fs.PathError{
+			Op:   "open",
+			Path: notFoundPidxFilePath,
+			Err:  expectedFileNotFoundError,
 		},
 	},
 }

--- a/cmd/commands/index_unix_test.go
+++ b/cmd/commands/index_unix_test.go
@@ -1,0 +1,13 @@
+//go:build !windows
+// +build !windows
+
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package commands_test
+
+import (
+	"syscall"
+)
+
+var expectedFileNotFoundError = syscall.ENOENT

--- a/cmd/commands/index_windows_test.go
+++ b/cmd/commands/index_windows_test.go
@@ -1,0 +1,13 @@
+//go:build windows
+// +build windows
+
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package commands_test
+
+import (
+	"syscall"
+)
+
+var expectedFileNotFoundError = syscall.ERROR_PATH_NOT_FOUND

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -10,21 +10,19 @@ import (
 )
 
 var InitCmd = &cobra.Command{
-	Use:   "init [--pack-root <pack root>] [index-url]",
+	Use:   "init [--pack-root <pack root>] <index-url>",
 	Short: "Initializes a pack root folder",
 	Long: `Initializes a pack root folder specified by -R/--pack-root command line
 or via the CMSIS_PACK_ROOT environment variable with the following contents:
   - .Download/
   - .Local/
   - .Web/
-  - .Web/index.pidx (downloaded from <index-url>)`,
-	Args: cobra.MaximumNArgs(1),
+  - .Web/index.pidx (downloaded from <index-url>)
+The index-url is mandatory. Ex "cpackget init --pack-root path/to/mypackroot https://www.keil.com/pack/index.pidx"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		packRoot := viper.GetString("pack-root")
-		var indexPath string
-		if len(args) > 0 {
-			indexPath = args[0]
-		}
+		indexPath := args[0]
 
 		log.Debugf("Initializing a new pack root in \"%v\" using index url \"%v\"", packRoot, indexPath)
 
@@ -34,10 +32,6 @@ or via the CMSIS_PACK_ROOT environment variable with the following contents:
 			return err
 		}
 
-		if len(indexPath) > 0 {
-			return installer.UpdatePublicIndex(indexPath, true)
-		}
-
-		return nil
+		return installer.UpdatePublicIndex(indexPath, true)
 	},
 }

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -406,6 +406,24 @@ func TestUpdatePublicIndex(t *testing.T) {
 		assert.Equal(copied, indexContent)
 	})
 
+	t.Run("test add local file index.pidx", func(t *testing.T) {
+		localTestingDir := "test-add-local-file-index"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		indexContent, err := ioutil.ReadFile(samplePublicIndex)
+		assert.Nil(err)
+
+		assert.Nil(installer.UpdatePublicIndex(samplePublicIndex, Overwrite))
+
+		assert.True(utils.FileExists(installer.Installation.PublicIndex))
+
+		copied, err2 := ioutil.ReadFile(installer.Installation.PublicIndex)
+		assert.Nil(err2)
+
+		assert.Equal(copied, indexContent)
+	})
+
 	t.Run("test do not overwrite index.pidx", func(t *testing.T) {
 		localTestingDir := "test-do-not-overwrite-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))

--- a/scripts/test-xmllint-localrepository
+++ b/scripts/test-xmllint-localrepository
@@ -9,7 +9,20 @@ PACK_ROOT=packroot
 rm -rf $PACK_ROOT
 
 export CMSIS_PACK_ROOT=${PACK_ROOT}
-./build/cpackget init
+
+cat <<PIDX >/tmp/index.pidx
+<?xml version="1.0" encoding="UTF-8" ?>
+<index schemaVersion="1.1.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
+    <vendor>TheVendor</vendor>
+    <url>http://the.vendor/</url>
+    <timestamp>2021-10-17T12:21:59.1747971+00:00</timestamp>
+    <pindex>
+        <pdsc url="http://the.vendor/" vendor="TheVendor" name="PackName" version="1.2.3" />
+    </pindex>
+</index>
+PIDX
+
+./build/cpackget init /tmp/index.pidx
 ./build/cpackget pdsc add testdata/devpack/1.2.3/TheVendor.DevPack.pdsc
 
 xmllint --schema testdata/PackIndex.xsd $PACK_ROOT/.Local/local_repository.pidx --noout


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/53

This patch makes mandatory that an index-url is specified when initializing a new pack-root directory. Ex:
```bash
# Do not allow if no index-url specified
$ cpackget init --pack-root /tmp/my-pack-root 
E: accepts 1 arg(s), received 0

# Initialize normally
$ cpackget init --pack-root /tmp/my-pack-root https://www.keil.com/pack/index.pidx
I: Using pack root: "/tmp/my-pack-root"
I: Downloading index.pidx 100% |██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| (100/100 kB, 181.983 kB/s)

# Make sure it is created OK
$ tree -a /tmp/my-pack-root/
/tmp/my-pack-root/
├── .Download
├── .Local
└── .Web
    └── index.pidx

3 directories, 1 file
```