### PR TITLE
Add prompt after license/EULA options

### DIFF
--- a/cmd/ui/eula.go
+++ b/cmd/ui/eula.go
@@ -43,6 +43,8 @@ func DisplayAndWaitForEULA(licenseTitle, licenseContents string) (bool, error) {
 	promptText := "License Agreement: [A]ccept [D]ecline [E]xtract"
 
 	if !utils.IsTerminalInteractive() {
+		// Show input on non-interactive terminals
+		promptText = "License Agreement: [A]ccept [D]ecline [E]xtract: "
 		fmt.Printf("*** %v ***", licenseTitle)
 		fmt.Println()
 		fmt.Println(licenseContents)


### PR DESCRIPTION
This PR adds sort of a prompt after license/EULA options on non-interactive terminals:

```bash
License Agreement: [A]ccept [D]ecline [E]xtract: 
```

While keeping just the options on interactive terminals (like gnome terminal).
Tested on `powershell`, `cmd.exe` and `git-bash.exe`. Closes #73.
