### PR TITLE
Fix pack add when version contains "quality" or "buildmetadata" bits in it

### DIFF
--- a/cmd/utils/packs_test.go
+++ b/cmd/utils/packs_test.go
@@ -4,6 +4,7 @@
 package utils_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -188,6 +189,141 @@ func TestExtractPackInfo(t *testing.T) {
 				Location:  localFilePrefix + absPath(filepath.Join(cwd, "..", "path", "to")) + string(os.PathSeparator),
 			},
 		},
+	}
+
+	// Test some extra samples extracted from semver.org
+	validSemanticVersions := []string{
+		"0.0.4",
+		"1.0.0",
+		"1.2.3",
+		"10.20.30",
+		"1.1.2-prerelease+meta",
+		"1.1.2+meta",
+		"1.1.2+meta-valid",
+		"1.0.0-alpha",
+		"1.0.0-beta",
+		"1.0.0-alpha.beta",
+		"1.0.0-alpha.beta.1",
+		"1.0.0-alpha.1",
+		"1.0.0-alpha.1.1",
+		"1.0.0-alpha.1.1.1",
+		"1.0.0-alpha0.valid",
+		"1.0.0-alpha.0valid",
+		"1.0.0-alpha-a.b-c-somethinglong+build.1-aef.1-its-okay",
+		"1.0.0-rc.1+build.1",
+		"2.0.0-rc.1+build.123",
+		"1.2.3-beta",
+		"10.2.3-DEV-SNAPSHOT",
+		"1.2.3-SNAPSHOT-123",
+		"2.0.0+build.1848",
+		"2.0.1-alpha.1227",
+		"1.0.0-alpha+beta",
+		"1.2.3----RC-SNAPSHOT.12.9.1--.12+788",
+		"1.2.3----R-S.12.9.1--.12+meta",
+		"1.2.3----RC-SNAPSHOT.12.9.1--.12",
+		"1.0.0+0.build.1-rc.10000aaa-kk-0.1",
+		"99999999999999999999999.999999999999999999.99999999999999999",
+		"1.0.0-0A.is.legal",
+	}
+	for _, version := range validSemanticVersions {
+		tests = append(tests, testCase{
+			name: fmt.Sprintf("test valid sem version %s", version),
+			path: fmt.Sprintf("TheVendor.ThePack.%s", version),
+			expected: utils.PackInfo{
+				Vendor:          "TheVendor",
+				Pack:            "ThePack",
+				Version:         version,
+				VersionModifier: utils.ExactVersion,
+				IsPackID:        true,
+			},
+		})
+
+		// Just for kicks, test it against ::@ as well
+		tests = append(tests, testCase{
+			name: fmt.Sprintf("test valid ::@ and sem version %s", version),
+			path: fmt.Sprintf("TheVendor::ThePack@%s", version),
+			expected: utils.PackInfo{
+				Vendor:          "TheVendor",
+				Pack:            "ThePack",
+				Version:         version,
+				VersionModifier: utils.ExactVersion,
+				IsPackID:        true,
+			},
+		})
+
+		// And test it as file name
+		tests = append(tests, testCase{
+			name: fmt.Sprintf("test valid file name with sem version %s", version),
+			path: fmt.Sprintf("TheVendor.ThePack.%s.pack", version),
+			expected: utils.PackInfo{
+				Vendor:    "TheVendor",
+				Pack:      "ThePack",
+				Version:   version,
+				Extension: "pack",
+				Location:  localFilePrefix + cwd + string(os.PathSeparator),
+			},
+		})
+	}
+
+	// Also test invalid semantic versions
+	invalidSemanticVersions := []string{
+		"1",
+		"1.2",
+		"1.2.3-0123",
+		"1.2.3-0123.0123",
+		"1.1.2+.123",
+		"+invalid",
+		"-invalid",
+		"-invalid+invalid",
+		"-invalid.01",
+		"alpha",
+		"alpha.beta",
+		"alpha.beta.1",
+		"alpha.1",
+		"alpha+beta",
+		"alpha_beta",
+		"alpha.",
+		"alpha..",
+		"beta",
+		"1.0.0-alpha_beta",
+		"-alpha.",
+		"1.0.0-alpha..",
+		"1.0.0-alpha..1",
+		"1.0.0-alpha...1",
+		"01.1.1",
+		"1.01.1",
+		"1.1.01",
+		"1.2",
+		"1.2.3.DEV",
+		"1.2-SNAPSHOT",
+		"1.2.31.2.3----RC-SNAPSHOT.12.09.1--..12+788",
+		"1.2-RC-SNAPSHOT",
+		"-1.0.3-gamma+b7718",
+		"+justmeta",
+		"9.8.7+meta+meta",
+		"9.8.7-whatever+meta+meta",
+		"99999999999999999999999.999999999999999999.99999999999999999----RC-SNAPSHOT.12.09.1--------------------------------..12",
+	}
+	for _, version := range invalidSemanticVersions {
+		tests = append(tests, testCase{
+			name: fmt.Sprintf("test invalid sem version %s", version),
+			path: fmt.Sprintf("TheVendor.ThePack.%s", version),
+			err:  errs.ErrBadPackName,
+		})
+
+		// Just for kicks, test it against ::@ as well
+		tests = append(tests, testCase{
+			name: fmt.Sprintf("test invalid ::@ and sem version %s", version),
+			path: fmt.Sprintf("TheVendor::ThePack@%s", version),
+			err:  errs.ErrBadPackName,
+		})
+
+		// And test it as file name
+		tests = append(tests, testCase{
+			name: fmt.Sprintf("test invalid file name with sem version %s", version),
+			path: fmt.Sprintf("TheVendor.ThePack.%s.pack", version),
+			err:  errs.ErrBadPackName,
+		})
 	}
 
 	for _, test := range tests {

--- a/cmd/utils/utils_test.go
+++ b/cmd/utils/utils_test.go
@@ -12,13 +12,24 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/open-cmsis-pack/cpackget/cmd/utils"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
+
+// Copy of cmd/log.go
+type LogFormatter struct{}
+
+func (s *LogFormatter) Format(entry *log.Entry) ([]byte, error) {
+	level := strings.ToUpper(entry.Level.String())
+	msg := fmt.Sprintf("%s: %s\n", level[0:1], entry.Message)
+	return []byte(msg), nil
+}
 
 func TestDownloadFile(t *testing.T) {
 	assert := assert.New(t)
@@ -474,4 +485,13 @@ func TestCleanPath(t *testing.T) {
 	expected := fmt.Sprintf("c:%csome%cpath", os.PathSeparator, os.PathSeparator)
 	result := utils.CleanPath(fmt.Sprintf("%cc:%csome%cpath", os.PathSeparator, os.PathSeparator, os.PathSeparator))
 	assert.Equal(t, expected, result)
+}
+
+func init() {
+	logLevel := log.InfoLevel
+	if os.Getenv("LOG_LEVEL") == "debug" {
+		logLevel = log.DebugLevel
+	}
+	log.SetLevel(logLevel)
+	log.SetFormatter(new(LogFormatter))
 }


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/80

Now cpackget can work on packs with any semantic-version compatible version
```
$ cpackget add Vendor.Pack.2.0.0-alpha.0.5.pack 
I: Using pack root: "../packroot"
I: Adding pack "Vendor.Pack.2.0.0-alpha.0.5.pack"
I: Extracting files to ../packroot/Vendor/Pack/2.0.0-alpha.0.5 100% |██████████| (3/3, 3950 it/s)
```

This PR also extends validation to a list of [valid](https://github.com/Open-CMSIS-Pack/cpackget/pull/81/files#diff-3e613a0145451ee1425c74122f77e17173e1a50c54782dfe4a0a10f458dbad10R195) and [invalid](https://github.com/Open-CMSIS-Pack/cpackget/pull/81/files#diff-3e613a0145451ee1425c74122f77e17173e1a50c54782dfe4a0a10f458dbad10R269) versions.