### PR TITLE
Avoid retrieving pack PDSC file when removing a pack

### DIFF
--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -41,6 +41,9 @@ type PackType struct {
 	// isPackID tells whether the path is in packID format: Vendor.PackName[.x.y.z]
 	isPackID bool
 
+	// toBeRemoved indicates
+	toBeRemoved bool
+
 	// exactVersion tells wether this pack identifier is specifying an exact version
 	// or is requesting a newer one, e.g. >=x.y.z
 	versionModifier int
@@ -63,9 +66,10 @@ type PackType struct {
 
 // preparePack does some sanity validation regarding pack name
 // and check if it's public and if it's installed or not
-func preparePack(packPath string) (*PackType, error) {
+func preparePack(packPath string, toBeRemoved bool) (*PackType, error) {
 	pack := &PackType{
-		path: packPath,
+		path:        packPath,
+		toBeRemoved: toBeRemoved,
 	}
 
 	// Clean out any possible query or user auth in the URL

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -23,7 +23,7 @@ import (
 // AddPack adds a pack to the pack installation directory structure
 func AddPack(packPath string, checkEula, extractEula bool, forceReinstall bool) error {
 
-	pack, err := preparePack(packPath)
+	pack, err := preparePack(packPath, false)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func RemovePack(packPath string, purge bool) error {
 	// TODO: by default, remove latest version first
 	// if no version is given
 
-	pack, err := preparePack(packPath)
+	pack, err := preparePack(packPath, true)
 	if err != nil {
 		return err
 	}
@@ -674,6 +674,11 @@ func (p *PacksInstallationType) packIsPublic(pack *PackType) (bool, error) {
 	if len(pdscTags) == 0 {
 		log.Debugf("Not found \"%s\" tag in \"%s\"", pack.PdscFileName(), p.PublicIndex)
 		return false, nil
+	}
+
+	// If the pack is being removed, there's no need to get its PDSC file under .Web
+	if pack.toBeRemoved {
+		return true, nil
 	}
 
 	// Sometimes a pidx file might have multiple pdsc tags for same key


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/82

It was taken as granted that if a pack PDSC isn't found in `.Web/`, cpackget would attempt to read the index.pidx file and download it.

So all public packs installed via cpackget will consequently have the PDSC file in `.Web/`. Nevertheless, there might be use cases where packs were installed elsewhere and the PDSC file isn't present. When removing such packs, cpackget would still attempt to retrieve the PDSC, which does not seem necessary.