### PR TITLE
Fix windows intermittent tests (again)

### DIFF
--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -63,19 +63,14 @@ func TestAddPack(t *testing.T) {
 			IsPublic: true,
 		})
 
-		packIdx, err := os.Stat(installer.Installation.PackIdx)
-		assert.Nil(err)
-		packIdxModTime := packIdx.ModTime()
+		packIdxModTime := getPackIdxModTime(t, Start)
 
 		// Attempt installing it again, this time it should noop
 		packPath = publicLocalPack123
-		err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall)
-		assert.Nil(err)
+		assert.Nil(installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall))
 
 		// Make sure pack.idx did NOT get touched
-		packIdx, err = os.Stat(installer.Installation.PackIdx)
-		assert.Nil(err)
-		assert.Equal(packIdxModTime, packIdx.ModTime())
+		assert.Equal(packIdxModTime, getPackIdxModTime(t, End))
 	})
 
 	t.Run("test force-reinstalling a pack not yet installed", func(t *testing.T) {

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -62,8 +61,28 @@ func shortenPackPath(packPath string, withVersion bool) string {
 	return packName[:stripLength]
 }
 
-func getPackIdxModTime() time.Time {
-	packIdx, _ := os.Stat(installer.Installation.PackIdx)
+func getPackIdxModTime(t *testing.T, pushBack bool) time.Time {
+	// This function helps retrieving mod time of pack.idx file.
+	// It is invoked before adding/removing packs to detect if the file really did get touched
+	// BUT:
+	// Apparently Windows systems update of file modified times
+	// happens 64 times per second, and in some cases that is not
+	// enough for the time delta  below to show a difference
+	// Ref: https://www.lochan.org/2005/keith-cl/useful/win32time.html#timingwin
+	// This caused intermittent test failures only on Windows environment.
+	// We tried sleeping for 1,2, and 3 seconds before checking for
+	// mod time of pack.idx but it still failed unexpectedly.
+	// So instead of sleeping only on Windows, we decided now to
+	// bring back the original check of pack.idx mod time in 1 day so
+	// next time it gets touched, the time delta will be great enough (we hope)
+	if pushBack {
+		//                              years, months, days
+		yesterday := time.Now().AddDate(0, 0, -1)
+		err := os.Chtimes(installer.Installation.PackIdx, yesterday, yesterday)
+		assert.Nil(t, err)
+	}
+	packIdx, err := os.Stat(installer.Installation.PackIdx)
+	assert.Nil(t, err)
 	return packIdx.ModTime()
 }
 
@@ -129,7 +148,7 @@ func removePack(t *testing.T, packPath string, withVersion, isPublic, purge bool
 	assert := assert.New(t)
 
 	// Get pack.idx before removing pack
-	packIdxModTime := getPackIdxModTime()
+	packIdxModTime := getPackIdxModTime(t, Start)
 
 	// [http://vendor.com|path/to]/TheVendor.PackName.x.y.z -> TheVendor.PackName[.x.y.z]
 	shortPackPath := shortenPackPath(packPath, withVersion)
@@ -173,23 +192,17 @@ func removePack(t *testing.T, packPath string, withVersion, isPublic, purge bool
 
 	// No touch on purging only
 	if !purgeOnly {
-		if runtime.GOOS == "windows" {
-			// Apparently Windows systems update of file modified times
-			// happens 64 times per second, and in some cases that is not
-			// enough for the time delta below to show a difference
-			// Ref: https://www.lochan.org/2005/keith-cl/useful/win32time.html#timingwin
-			// So let's sleep a bit before checking for file mod times
-			// Sleeping for 1 second still caused interemittent results on Windows,
-			// bumping this up to 3 seconds
-			time.Sleep(3 * time.Second)
-		}
 
 		// Make sure the pack.idx file gets trouched
-		assert.True(packIdxModTime.Before(getPackIdxModTime()))
+		assert.True(packIdxModTime.Before(getPackIdxModTime(t, End)))
 	}
 }
 
 var (
+	// Constants to help getting pack.idx mod time
+	Start = true
+	End   = false
+
 	// Constant telling pack privacy
 	IsPublic       = true
 	NotPublic      = false


### PR DESCRIPTION
Re-addressing this issue: https://github.com/Open-CMSIS-Pack/cpackget/pull/26

In order to expand delta time by sleeping, this PR changes mod time of pack.idx to yesterday so when it gets touched, the delta is going to be great enough to cause the test not to fail.