### PR TITLE
Don't install unavailable versions

### DIFF
--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -66,7 +66,7 @@ var (
 	ErrPackPdscCannotBeFound           = errors.New("the URL for the pack pdsc file seems not to exist or it didn't return the file")
 	ErrPackVersionNotFoundInPdsc       = errors.New("pack version not found in the pdsc file")
 	ErrPackVersionNotLatestReleasePdsc = errors.New("pack version is not the latest in the pdsc file")
-	ErrPackVersionMinimumNotSatisfied  = errors.New("target minimum pack version can't be satisfied")
+	ErrPackVersionNotAvailable         = errors.New("target pack version is not available")
 	ErrPackURLCannotBeFound            = errors.New("URL for the pack cannot be determined. Please consider updating the public index. Ex: cpackget index --force https://keil.com/pack/index.pidx")
 
 	// Hack to allow multiple error logs while still avoiding duplicating the last error log

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -66,6 +66,7 @@ var (
 	ErrPackPdscCannotBeFound           = errors.New("the URL for the pack pdsc file seems not to exist or it didn't return the file")
 	ErrPackVersionNotFoundInPdsc       = errors.New("pack version not found in the pdsc file")
 	ErrPackVersionNotLatestReleasePdsc = errors.New("pack version is not the latest in the pdsc file")
+	ErrPackVersionMinimumNotSatisfied  = errors.New("target minimum pack version can't be satisfied")
 	ErrPackURLCannotBeFound            = errors.New("URL for the pack cannot be determined. Please consider updating the public index. Ex: cpackget index --force https://keil.com/pack/index.pidx")
 
 	// Hack to allow multiple error logs while still avoiding duplicating the last error log

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -459,7 +459,7 @@ func (p *PackType) resolveVersionModifier(pdscXML *xml.PdscXML) {
 	if p.versionModifier == utils.GreaterVersion {
 		// No minimum version exists to satisfy target version
 		if p.targetVersion == "" && semver.Compare("v"+p.Version, "v"+pdscXML.LatestVersion()) > 0 {
-			log.Errorf("Tried to install atleast version %s, highest available version is %s", p.Version, pdscXML.LatestVersion())
+			log.Errorf("Tried to install at least version %s, highest available version is %s", p.Version, pdscXML.LatestVersion())
 		} else {
 			p.targetVersion = pdscXML.LatestVersion()
 			log.Debugf("- resolved(>=) as %s", p.targetVersion)
@@ -479,7 +479,7 @@ func (p *PackType) resolveVersionModifier(pdscXML *xml.PdscXML) {
 				return
 			}
 		}
-		// Check if atleast same Major version exists
+		// Check if at least same Major version exists
 		if semver.Compare("v"+p.targetVersion, "v"+p.Version) > 0 {
 			p.targetVersion = pdscXML.LatestVersion()
 			log.Debugf("- resolved (@~) as %s", p.targetVersion)

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -417,6 +417,19 @@ func FindPackURL(pack *PackType) (string, error) {
 		pack.resolveVersionModifier(packPdscXML)
 
 		releaseTag := packPdscXML.FindReleaseTagByVersion(pack.targetVersion)
+
+		// Can't satisfy minimum target version
+		if pack.versionModifier == utils.GreaterVersion || pack.versionModifier == utils.GreatestCompatibleVersion {
+			if semver.Compare("v"+releaseTag.Version, "v"+pack.Version) < 0 {
+				return "", errs.ErrPackVersionNotAvailable
+			}
+		}
+		if pack.versionModifier == utils.GreatestCompatibleVersion {
+			if semver.Major("v"+releaseTag.Version) != semver.Major("v"+pack.Version) {
+				return "", errs.ErrPackVersionNotAvailable
+			}
+		}
+
 		if releaseTag == nil {
 			return "", errs.ErrPackVersionNotFoundInPdsc
 		}
@@ -442,6 +455,18 @@ func FindPackURL(pack *PackType) (string, error) {
 	pack.resolveVersionModifier(packPdscXML)
 
 	releaseTag := packPdscXML.FindReleaseTagByVersion(pack.targetVersion)
+
+	if pack.versionModifier == utils.GreaterVersion {
+		if semver.Compare("v"+releaseTag.Version, "v"+pack.Version) < 0 {
+			return "", errs.ErrPackVersionNotAvailable
+		}
+	}
+	if pack.versionModifier == utils.GreatestCompatibleVersion {
+		if semver.Major("v"+releaseTag.Version) != semver.Major("v"+pack.Version) {
+			return "", errs.ErrPackVersionNotAvailable
+		}
+	}
+
 	if releaseTag == nil {
 		return "", errs.ErrPackVersionNotFoundInPdsc
 	}

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -574,8 +574,19 @@ func (p *PacksInstallationType) PackIsInstalled(pack *PackType) bool {
 		return utils.DirExists(packDir)
 	}
 
-	// Now get all versions installed and check if it satisfies the versionModifier condition
 	installedVersions := []string{}
+	// Gather all versions in local_repository.idx for local .psdc installed packs
+	if err := p.LocalPidx.Read(); err != nil {
+		log.Warn("Could not read local index")
+		return false
+	}
+	for _, pdsc := range p.LocalPidx.ListPdscTags() {
+		if pack.Vendor == pdsc.Vendor && pack.Name == pdsc.Name {
+			installedVersions = append(installedVersions, pdsc.Version)
+		}
+	}
+
+	// Get all remaining versions installed and check if it satisfies the versionModifier condition
 	installedDirs, err := utils.ListDir(installationDir, "")
 	if err != nil {
 		log.Warnf("Could not list installed packs in \"%s\": %v", installationDir, err)

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -971,6 +971,25 @@ func TestAddPack(t *testing.T) {
 		checkPackIsInstalled(t, &pack124)
 	})
 
+	t.Run("test installing a pack with a minimum version specified higher than the latest available", func(t *testing.T) {
+		// This test case checks the following use case:
+		// 1. There are no packs installed
+		// 2. Versions 1.2.2, 1.2.3, 1.2.4 are available to install
+		// 3. Attempt to install >=1.2.5
+		// 4. Should fail as the minimum version is not available to install
+
+		localTestingDir := "test-installing-pack-with-minimum-version-higher-latest"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		// Inject pdsc into .Web folder
+		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
+		assert.Nil(utils.CopyFile(pdscPublicLocalPack, packPdscFilePath))
+
+		err := installer.AddPack(publicLocalPack125WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall)
+		assert.Equal(err, errs.ErrPackVersionNotAvailable)
+	})
+
 	t.Run("test installing a pack with a minimum compatible version specified and newer major version pre-installed", func(t *testing.T) {
 		// This test case checks the following use case:
 		// 1. There's already a pack 1.2.4 installed
@@ -1135,6 +1154,25 @@ func TestAddPack(t *testing.T) {
 		packIdx, err = os.Stat(installer.Installation.PackIdx)
 		assert.Nil(err)
 		assert.Equal(packIdxModTime, packIdx.ModTime())
+	})
+
+	t.Run("test installing a pack with a minimum compatible version higher than the latest available", func(t *testing.T) {
+		// This test case checks the following use case:
+		// 1. There are no packs installed
+		// 2. Versions 1.2.2, 1.2.3, 1.2.4 are available to install
+		// 3. Attempt to install @~2.1.1
+		// 4. Should fail as the minimum comaptible version is not available to install
+
+		localTestingDir := "test-installing-pack-with-minimum-compatible-version-higher-latest"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		// Inject pdsc into .Web folder
+		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
+		assert.Nil(utils.CopyFile(pdscPublicLocalPack, packPdscFilePath))
+
+		err := installer.AddPack(publicLocalPack211WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall)
+		assert.Equal(err, errs.ErrPackVersionNotAvailable)
 	})
 
 	t.Run("test installing a pack with @latest version specified without any pre-installed version", func(t *testing.T) {

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -222,8 +222,10 @@ var (
 	publicLocalPackLegacyPackID                                = "TheVendor::PublicLocalPack"
 	publicRemotePack123LegacyPackID                            = publicRemotePackLegacyPackID + "@1.2.3"
 	publicLocalPack123WithMinimumVersionLegacyPackID           = publicLocalPackLegacyPackID + ">=1.2.3"
+	publicLocalPack125WithMinimumVersionLegacyPackID           = publicLocalPackLegacyPackID + ">=1.2.5"
 	publicLocalPack010WithMinimumCompatibleVersionLegacyPackID = publicLocalPackLegacyPackID + "@~0.1.0"
 	publicLocalPack011WithMinimumCompatibleVersionLegacyPackID = publicLocalPackLegacyPackID + "@~0.1.1"
+	publicLocalPack211WithMinimumCompatibleVersionLegacyPackID = publicLocalPackLegacyPackID + "@~2.1.1"
 	publicLocalPackLatestVersionLegacyPackID                   = publicLocalPackLegacyPackID + "@latest"
 
 	// Pdsc files to test out installing packs with pack id only


### PR DESCRIPTION
Fixes #48. As described in the issue:

- local_repository.idx is now checked first and foremost when listing/checking for installed pack versions
- Trying to install a version (such as >= or @~) that is not available won't install the latest version, but will throw an error and tell the user what's the "closest" version there is.