### PR TITLE
Allow filtering when listing packs

### DIFF
--- a/cmd/commands/list.go
+++ b/cmd/commands/list.go
@@ -14,6 +14,9 @@ var listCmdFlags struct {
 
 	// listCached tells whether listing all cached packs
 	listCached bool
+
+	// listFilter is a set of words by which to filter listed packs
+	listFilter string
 }
 
 var ListCmd = &cobra.Command{
@@ -23,11 +26,12 @@ var ListCmd = &cobra.Command{
 	Args:              cobra.MaximumNArgs(0),
 	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return installer.ListInstalledPacks(listCmdFlags.listCached, listCmdFlags.listPublic)
+		return installer.ListInstalledPacks(listCmdFlags.listCached, listCmdFlags.listPublic, listCmdFlags.listFilter)
 	},
 }
 
 func init() {
 	ListCmd.Flags().BoolVarP(&listCmdFlags.listCached, "cached", "c", false, "list only cached packs")
 	ListCmd.Flags().BoolVarP(&listCmdFlags.listPublic, "public", "p", false, "list packs in the public index")
+	ListCmd.Flags().StringVarP(&listCmdFlags.listFilter, "filter", "f", "", "filter results (case sensitive, accepts several expressions)")
 }

--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -39,6 +39,9 @@ var listPublic bool
 // listCached tells whether listing all cached packs
 var listCached bool
 
+// listFilter is a set of words by which to filter listed packs
+var listFilter string
+
 var packAddCmd = &cobra.Command{
 	Use:   "add [<pack path> | -f <packs list>]",
 	Short: "Adds Open-CMSIS-Pack packages",
@@ -122,7 +125,7 @@ var packListCmd = &cobra.Command{
 	Long:  `Lists all installed packs and optionally cached pack files`,
 	Args:  cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return installer.ListInstalledPacks(listCached, listPublic)
+		return installer.ListInstalledPacks(listCached, listPublic, listFilter)
 	},
 }
 

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -239,7 +239,7 @@ func ListInstalledPacks(listCached, listPublic bool, listFilter string) error {
 			}
 
 			// To avoid showing empty log lines ("I: ")
-			if listFilter == "" || utils.FilterPackId(logMessage, listFilter) != "" {
+			if listFilter == "" || utils.FilterPackID(logMessage, listFilter) != "" {
 				log.Info(logMessage)
 			}
 		}
@@ -282,7 +282,7 @@ func ListInstalledPacks(listCached, listPublic bool, listFilter string) error {
 				logMessage += " (installed)"
 			}
 
-			if listFilter == "" || utils.FilterPackId(logMessage, listFilter) != "" {
+			if listFilter == "" || utils.FilterPackID(logMessage, listFilter) != "" {
 				log.Info(logMessage)
 			}
 		}
@@ -390,22 +390,21 @@ func ListInstalledPacks(listCached, listPublic bool, listFilter string) error {
 				if pack.err != nil {
 					logMessage += fmt.Sprintf(", %v", pack.err)
 				}
-				if listFilter != "" && utils.FilterPackId(logMessage, listFilter) != "" {
+				if listFilter != "" && utils.FilterPackID(logMessage, listFilter) != "" {
 					printWarning = false
 				}
 				log.Error(logMessage)
 			} else if pack.err != nil {
 				numErrors += 1
 				logMessage += fmt.Sprintf(" - error: %v", pack.err)
-				if listFilter != "" && utils.FilterPackId(logMessage, listFilter) != "" {
+				if listFilter != "" && utils.FilterPackID(logMessage, listFilter) != "" {
 					printWarning = false
 				}
 				log.Error(logMessage)
 			} else {
-				if listFilter != "" && utils.FilterPackId(logMessage, listFilter) != "" {
-					printWarning = false
+				if listFilter == "" || utils.FilterPackID(logMessage, listFilter) != "" {
+					log.Info(logMessage)
 				}
-				log.Info(logMessage)
 			}
 		}
 

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -208,10 +208,15 @@ func UpdatePublicIndex(indexPath string, overwrite bool) error {
 }
 
 // ListInstalledPacks generates a list of all packs present in the pack root folder
-func ListInstalledPacks(listCached, listPublic bool) error {
+func ListInstalledPacks(listCached, listPublic bool, listFilter string) error {
 	log.Debugf("Listing packs")
 	if listPublic {
-		log.Info("Listing packs from the public index")
+		if listFilter != "" {
+			log.Infof("Listing packs from the public index, filtering by \"%s\"", listFilter)
+		} else {
+			log.Infof("Listing packs from the public index")
+		}
+
 		pdscTags := Installation.PublicIndexXML.ListPdscTags()
 
 		if len(pdscTags) == 0 {
@@ -232,10 +237,18 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 			} else if utils.FileExists(packFilePath) {
 				logMessage += " (cached)"
 			}
-			log.Info(logMessage)
+
+			// To avoid showing empty log lines ("I: ")
+			if listFilter == "" || utils.FilterPackId(logMessage, listFilter) != "" {
+				log.Info(logMessage)
+			}
 		}
 	} else if listCached {
-		log.Info("Listing cached packs")
+		if listFilter != "" {
+			log.Infof("Listing cached packs, filtering by \"%s\"", listFilter)
+		} else {
+			log.Infof("Listing cached packs")
+		}
 		pattern := filepath.Join(Installation.DownloadDir, "*.pack")
 		matches, err := filepath.Glob(pattern)
 		if err != nil {
@@ -269,10 +282,16 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 				logMessage += " (installed)"
 			}
 
-			log.Info(logMessage)
+			if listFilter == "" || utils.FilterPackId(logMessage, listFilter) != "" {
+				log.Info(logMessage)
+			}
 		}
 	} else {
-		log.Info("Listing installed packs")
+		if listFilter != "" {
+			log.Infof("Listing installed packs, filtering by \"%s\"", listFilter)
+		} else {
+			log.Infof("Listing installed packs")
+		}
 
 		type installedPack struct {
 			xml.PdscTag
@@ -337,6 +356,7 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 		}
 
 		numErrors := 0
+		printWarning := true
 		sort.Slice(installedPacks, func(i, j int) bool {
 			return strings.ToLower(installedPacks[i].Key()) < strings.ToLower(installedPacks[j].Key())
 		})
@@ -356,31 +376,40 @@ func ListInstalledPacks(listCached, listPublic bool) error {
 				errors = append(errors, "pack version")
 			}
 
-			message := pack.YamlPackID()
+			logMessage := pack.YamlPackID()
 
 			// Print the PDSC path on packs installed via PDSC file
 			if pack.isPdscInstalled {
-				message += fmt.Sprintf(" (installed via %s)", pack.pdscPath)
+				logMessage += fmt.Sprintf(" (installed via %s)", pack.pdscPath)
 			}
 
 			// Append errors to the message, if any
 			if len(errors) > 0 {
 				numErrors += 1
-				message += " - error: " + strings.Join(errors[:], ", ") + " incorrect format"
+				logMessage += " - error: " + strings.Join(errors[:], ", ") + " incorrect format"
 				if pack.err != nil {
-					message += fmt.Sprintf(", %v", pack.err)
+					logMessage += fmt.Sprintf(", %v", pack.err)
 				}
-				log.Error(message)
+				if listFilter != "" && utils.FilterPackId(logMessage, listFilter) != "" {
+					printWarning = false
+				}
+				log.Error(logMessage)
 			} else if pack.err != nil {
 				numErrors += 1
-				message += fmt.Sprintf(" - error: %v", pack.err)
-				log.Error(message)
+				logMessage += fmt.Sprintf(" - error: %v", pack.err)
+				if listFilter != "" && utils.FilterPackId(logMessage, listFilter) != "" {
+					printWarning = false
+				}
+				log.Error(logMessage)
 			} else {
-				log.Info(message)
+				if listFilter != "" && utils.FilterPackId(logMessage, listFilter) != "" {
+					printWarning = false
+				}
+				log.Info(logMessage)
 			}
 		}
 
-		if numErrors > 0 {
+		if numErrors > 0 && printWarning {
 			log.Warnf("%d error(s) detected", numErrors)
 		}
 	}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -277,6 +277,28 @@ func CountLines(content string) int {
 	}
 }
 
+// FilterPackId returns the original string if any of the
+// received filter words are present - designed specifically to filter pack IDs
+func FilterPackId(content string, filter string) string {
+	log.Debugf("Filtering by words \"%s\"", filter)
+
+	// Don't accept the separator or version char
+	if filter == "" || strings.ContainsAny(filter, ":") || strings.ContainsAny(filter, "@") {
+		return ""
+	}
+
+	words := strings.Split(filter, " ")
+	// We're only interested in the first "word" (pack id)
+	target := strings.Split(content, " ")[0]
+
+	for w := 0; w < len(words); w++ {
+		if strings.Contains(target, words[w]) {
+			return target
+		}
+	}
+	return ""
+}
+
 // IsTerminalInteractive tells whether or not the current terminal is
 // capable of complex interactions
 func IsTerminalInteractive() bool {

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -279,7 +279,7 @@ func CountLines(content string) int {
 
 // FilterPackId returns the original string if any of the
 // received filter words are present - designed specifically to filter pack IDs
-func FilterPackId(content string, filter string) string {
+func FilterPackID(content string, filter string) string {
 	log.Debugf("Filtering by words \"%s\"", filter)
 
 	// Don't accept the separator or version char

--- a/cmd/utils/utils_test.go
+++ b/cmd/utils/utils_test.go
@@ -481,6 +481,13 @@ func TestCountLines(t *testing.T) {
 	assert.Equal(t, 3, utils.CountLines("this\nis\r\nacool\ncontent"))
 }
 
+func TestFilterPackId(t *testing.T) {
+	assert.Equal(t, "", utils.FilterPackID("TheVendor::Pack@1.2.3", ""))
+	assert.Equal(t, "", utils.FilterPackID("TheVendor::Pack@1.2.3", ":"))
+	assert.Equal(t, "", utils.FilterPackID("TheVendor::Pack@1.2.3", "@"))
+	assert.Equal(t, "TheVendor::Pack@1.2.3", utils.FilterPackID("TheVendor::Pack@1.2.3", "Vendor"))
+}
+
 func TestCleanPath(t *testing.T) {
 	expected := fmt.Sprintf("c:%csome%cpath", os.PathSeparator, os.PathSeparator)
 	result := utils.CleanPath(fmt.Sprintf("%cc:%csome%cpath", os.PathSeparator, os.PathSeparator, os.PathSeparator))


### PR DESCRIPTION
This PR addresses #63 and allows to filter listed packs (public, cached or installed) by any number of case-sensitive words.

These should be alphanumeric and any pack spec reserved chars won't be filtered:

```bash
$ build/cpackget list --filter "Vendor"
I: Using pack root: "/tmp/pack-root"
I: Listing installed packs, filtering by "Vendor"
I: TheVendor::ThePack@1.2.4

$ build/cpackget list --public --filter "SSL" 
I: Using pack root: "/tmp/pack-root"
I: Listing packs from the public index, filtering by "SSL"
I: RealTimeLogic::SharkSSL-Lite@38.9.8
I: wolfSSL::wolfSSL@5.3.0 (installed)

$ build/cpackget list --public -f "@"
I: Using pack root: "/tmp/pack-root"
I: Listing packs from the public index, filtering by "@"

$ build/cpackget list --public -f ":"
I: Using pack root: "/tmp/pack-root"
I: Listing packs from the public index, filtering by ":"

$ build/cpackget list --public -f "SSL Logic"
I: Using pack root: "/tmp/pack-root"
I: Listing packs from the public index, filtering by "SSL Logic"
I: RealTimeLogic::SharkSSL-Lite@38.9.8
I: RealTimeLogic::SMQ@38.9.8
I: wolfSSL::wolfSSL@5.3.0 (installed)
```
EDIT: Updated with bash prompt