### PR TITLE
commands: update-index: create the update-index command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Usage:
   cpackget [command] [flags]
 
 Available Commands:
-  help        Help about any command
-  index       Update public index
-  init        Initialize a pack root folder
-  add         Add Open-CMSIS-Pack packages
-  rm          Remove Open-CMSIS-Pack packages
-  list        List installed packs
+  add          Add Open-CMSIS-Pack packages
+  help         Help about any command
+  init         Initializes a pack root folder
+  list         List installed packs
+  rm           Remove Open-CMSIS-Pack packages
+  update-index Update the public index
 
 Flags:
   -h, --help               help for cpackget
@@ -141,6 +141,18 @@ Remove all versions of pack `Vendor.PackName`, from the local packs.
 * `cpackget rm Vendor.PackName` or `cpackget rm Vendor::PackName`
 
 Note that removing packs does not require path of PDSC file location specification, e.g. no need to provide the path for the PDSC file or the URL of the pack.
+
+### Updating the index
+
+It is common that the index.pidx file gets outdated sometime after the pack installation is initialized.
+A good practice is to keep it always updated. One can do that by running
+* `cpackget update-index`
+
+This will use the address from the `<url>` tag inside index.pidx to retrieve a new version of the file.
+cpackget will also go through all PDSC files within `.Web/` checking if the latest version has been
+oudated by the one matching the pack tag in index.pidx.
+
+If wanted, the behavior above can be disabled by using `--sparse` flag, thus updating only the index.pidx.
 
 ### Working behind a proxy
 

--- a/cmd/commands/index.go
+++ b/cmd/commands/index.go
@@ -13,8 +13,9 @@ import (
 var overwrite bool
 
 var IndexCmd = &cobra.Command{
-	Use:   "index <index url>",
-	Short: "Updates public index",
+	Deprecated: "Consider running `cpackget update-index` instead",
+	Use:        "index <index url>",
+	Short:      "Updates public index",
 	Long: `Updates the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the file specified by the given url.
 If there's already an index file, cpackget won't overwrite it. Use "-f" to do so.`,
 	PersistentPreRunE: configureInstaller,
@@ -22,7 +23,7 @@ If there's already an index file, cpackget won't overwrite it. Use "-f" to do so
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Updating index %v", args)
 		indexPath := args[0]
-		return installer.UpdatePublicIndex(indexPath, overwrite)
+		return installer.UpdatePublicIndex(indexPath, overwrite, true)
 	},
 }
 

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -32,6 +32,6 @@ The index-url is mandatory. Ex "cpackget init --pack-root path/to/mypackroot htt
 			return err
 		}
 
-		return installer.UpdatePublicIndex(indexPath, true)
+		return installer.UpdatePublicIndex(indexPath, true, true)
 	},
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -25,6 +25,7 @@ var AllCommands = []*cobra.Command{
 	AddCmd,
 	RmCmd,
 	ListCmd,
+	UpdateIndexCmd,
 }
 
 // createPackRoot is a flag that determines if the pack root should be created or not

--- a/cmd/commands/update_index.go
+++ b/cmd/commands/update_index.go
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package commands
+
+import (
+	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var updateIndexCmdFlags struct {
+	// sparse indicates whether the update should update all installed pack's pdscs (false) or simply update the index (true)
+	sparse bool
+}
+
+var UpdateIndexCmd = &cobra.Command{
+	Use:   "update-index",
+	Short: "Update the public index",
+	Long: `Update the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the URL in <url> tag inside index.pidx.
+By default it will also check if all PDSC files under .Web/ need update as well. This can be disabled via the "--sparse" flag.`,
+	PersistentPreRunE: configureInstaller,
+	Args:              cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		log.Infof("Updating public index")
+		return installer.UpdatePublicIndex("", true, updateIndexCmdFlags.sparse)
+	},
+}
+
+func init() {
+	UpdateIndexCmd.Flags().BoolVarP(&updateIndexCmdFlags.sparse, "sparse", "s", false, "avoid updating the pdsc files within .Web/ folder")
+}

--- a/cmd/commands/update_index_test.go
+++ b/cmd/commands/update_index_test.go
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package commands_test
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+)
+
+var updateIndexServer Server
+var updateIndexCmdTests = []TestCase{
+	{
+		name:        "test no parameter is required",
+		args:        []string{"update-index", "index.pidx"},
+		expectedErr: errors.New("accepts 0 arg(s), received 1"),
+	},
+	{
+		name:           "test updating index",
+		args:           []string{"update-index"},
+		createPackRoot: true,
+		expectedStdout: []string{"Updating public index", "Downloading index.pidx"},
+		setUpFunc: func(t *TestCase) {
+			indexContent := `<?xml version="1.0" encoding="UTF-8" ?> 
+<index schemaVersion="1.1.0" xs:noNamespaceSchemaLocation="PackIndex.xsd" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance">
+<vendor>TheVendor</vendor>
+<url>%s</url>
+<timestamp>2021-10-17T12:21:59.1747971+00:00</timestamp>
+<pindex>
+  <pdsc url="http://the.vendor/" vendor="TheVendor" name="PackName" version="1.2.3" />
+</pindex>
+</index>`
+			indexContent = fmt.Sprintf(indexContent, updateIndexServer.URL())
+			_ = ioutil.WriteFile(installer.Installation.PublicIndex, []byte(indexContent), 0600)
+
+			updateIndexServer.AddRoute("index.pidx", []byte(indexContent))
+		},
+	},
+}
+
+func TestUpdateIndexCmd(t *testing.T) {
+	updateIndexServer = NewServer()
+	runTests(t, updateIndexCmdTests)
+}

--- a/testdata/integration/1.2.4/TheVendor.PublicLocalPack.pdsc
+++ b/testdata/integration/1.2.4/TheVendor.PublicLocalPack.pdsc
@@ -5,6 +5,7 @@
    <name>PublicLocalPack</name>
    <description>Sample pack just for testing</description>
    <releases>
+      <release version="1.2.4" date="2016-09-15">New release.</release>
       <release version="1.2.3" date="2016-09-15">New release.</release>
       <release version="1.2.2">Initial release.</release>
    </releases>


### PR DESCRIPTION
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/54 
Fix https://github.com/Open-CMSIS-Pack/cpackget/issues/89

This command is a replacement of "index" command, except that it now takes the URL from within the current index.pidx file.

It also checks if PDSC files inside `.Web/` need updating or not.

Here are a few examples:

```bash
$ ./build/cpackget update-index
I: Using pack root: "../packroot"
I: Updating public index
W: Non-HTTPS url: "http://www.keil.com/pack/index.pidx"
I: Downloading index.pidx 100% || (101/101 kB, 173.548 kB/s)        
I: Updating PDSC files of installed packs referenced in index.pidx
I: ARM::CMSIS can be upgraded from "5.8.0" to "5.9.0"
I: Downloading ARM.CMSIS.pdsc 100% || (199/199 kB, 459.855 kB/s)
```
Note that before the update, `ARM::CMSIS@5.8.0` was installed. After updating the index.pidx, there is a message saying that the pack can be upgraded and a newer `ARM.CMSIS.pdsc` file gets downloaded.

The flag `--sparse` can be invoked to avoid updating PDSC files.