### PR TITLE
Cryptography module, integrity checking commands and small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# App related
 build/
 testing.log
 *.out
@@ -5,3 +6,5 @@ testing.log
 .cpackget*
 tmp/
 .vagrant/
+# IDEs
+.vscode/

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -17,7 +17,7 @@ var checksumCreateCmdFlags struct {
 }
 
 func init() {
-	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.hashAlgorithm, "hash-function", "a", "", "specifies the hash function to be used")
+	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.hashAlgorithm, "hash-function", "a", cryptography.Hashes[0], "specifies the hash function to be used")
 	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.outputDir, "output-dir", "o", "", "specifies output directory for the checksum file")
 }
 

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -19,14 +19,28 @@ var checksumCreateCmdFlags struct {
 }
 
 func init() {
-	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.hashAlgorithm, "hash-algorithm", "a", "", "specifies the hash function to be used")
+	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.hashAlgorithm, "hash-function", "a", "", "specifies the hash function to be used")
 	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.outputDir, "output-dir", "o", "", "specifies output directory for the checksum file")
 }
 
 var ChecksumCreateCmd = &cobra.Command{
 	Use:   "checksum-create [<local .path pack>]",
 	Short: "Generates a .checksum file containing the digests of a pack",
-	// TODO: Long, show valid hash algorithms
+	Long: `
+Creates a .checksum file of a local pack. This is file contains the digests
+of the contents of the pack. Example <Vendor.Pack.1.2.3.sha256.checksum> file:
+
+  "6f95628e4e0824b0ff4a9f49dad1c3eb073b27c2dd84de3b985f0ef3405ca9ca Vendor.Pack.1.2.3.pdsc
+  435fsdf..."
+
+  The referenced pack must be in its original/compressed from (.pack), and be present locally:
+
+  $ cpackget checksum-create Vendor.Pack.1.2.3.pack
+
+The default Cryptographic Hash Function used is "` + cryptography.Hashes[0] + `". In the future other hash functions
+might be supported. The used function will be prefixed to the ".checksum" extension.
+
+By default the checksum file will be created in the same directory as the provided pack.`,
 	Args:              cobra.MinimumNArgs(0),
 	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -43,7 +57,14 @@ var ChecksumCreateCmd = &cobra.Command{
 var ChecksumVerifyCmd = &cobra.Command{
 	Use:   "checksum-verify [<local .path pack>] [<local .checksum path>]",
 	Short: "Verifies the integrity of a pack using its .checksum file",
-	// TODO: Long
+	Long: `
+Verifies the contents of a pack, checking its integrity against its .checksum file (created
+with "checksum-create"):
+
+  $ cpackget checksum-verify Vendor.Pack.1.2.3.pack Vendor.Pack.1.2.3.sha256.checksum
+
+The used hash function is inferred from the checksum filename, and if any of the digests
+computed doesn't match the one provided in the checksum file an error will be thrown.`,
 	Args:              cobra.MinimumNArgs(0),
 	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -5,8 +5,6 @@ package commands
 
 import (
 	"github.com/open-cmsis-pack/cpackget/cmd/cryptography"
-	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -41,15 +39,9 @@ The default Cryptographic Hash Function used is "` + cryptography.Hashes[0] + `"
 might be supported. The used function will be prefixed to the ".checksum" extension.
 
 By default the checksum file will be created in the same directory as the provided pack.`,
-	Args:              cobra.MinimumNArgs(0),
+	Args:              cobra.ExactArgs(1),
 	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		if len(args) == 0 {
-			log.Error("missing .pack local path")
-			return errs.ErrIncorrectCmdArgs
-		}
-
 		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
 	},
 }
@@ -65,15 +57,9 @@ with "checksum-create"):
 
 The used hash function is inferred from the checksum filename, and if any of the digests
 computed doesn't match the one provided in the checksum file an error will be thrown.`,
-	Args:              cobra.MinimumNArgs(0),
+	Args:              cobra.ExactArgs(2),
 	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		if len(args) != 2 {
-			log.Error("Please provide path to pack and checksum file")
-			return errs.ErrIncorrectCmdArgs
-		}
-
 		return cryptography.VerifyChecksum(args[0], args[1])
 	},
 }

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -39,8 +39,7 @@ The default Cryptographic Hash Function used is "` + cryptography.Hashes[0] + `"
 might be supported. The used function will be prefixed to the ".checksum" extension.
 
 By default the checksum file will be created in the same directory as the provided pack.`,
-	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstaller,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
 	},
@@ -57,8 +56,7 @@ with "checksum-create"):
 
 The used hash function is inferred from the checksum filename, and if any of the digests
 computed doesn't match the one provided in the checksum file an error will be thrown.`,
-	Args:              cobra.ExactArgs(2),
-	PersistentPreRunE: configureInstaller,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cryptography.VerifyChecksum(args[0], args[1])
 	},

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -33,7 +33,7 @@ of the contents of the pack. Example <Vendor.Pack.1.2.3.sha256.checksum> file:
   "6f95628e4e0824b0ff4a9f49dad1c3eb073b27c2dd84de3b985f0ef3405ca9ca Vendor.Pack.1.2.3.pdsc
   435fsdf..."
 
-  The referenced pack must be in its original/compressed from (.pack), and be present locally:
+  The referenced pack must be in its original/compressed form (.pack), and be present locally:
 
   $ cpackget checksum-create Vendor.Pack.1.2.3.pack
 

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package commands
+
+import (
+	"github.com/open-cmsis-pack/cpackget/cmd/cryptography"
+	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var checksumCreateCmdFlags struct {
+	// hashAlgorithm is the cryptographic hash function to be used
+	hashAlgorithm string
+
+	// outputDir is the target directory where the checksum file is written to
+	outputDir string
+}
+
+func init() {
+	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.hashAlgorithm, "hash-algorithm", "a", "", "specifies the hash function to be used")
+	ChecksumCreateCmd.Flags().StringVarP(&checksumCreateCmdFlags.outputDir, "output-dir", "o", "", "specifies output directory for the checksum file")
+}
+
+var ChecksumCreateCmd = &cobra.Command{
+	Use:   "checksum-create [<local .path pack>]",
+	Short: "Generates a .checksum file containing the digests of a pack",
+	// TODO: Long, show valid hash algorithms
+	Args:              cobra.MinimumNArgs(0),
+	PersistentPreRunE: configureInstaller,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) == 0 {
+			log.Error("missing .pack local path")
+			return errs.ErrIncorrectCmdArgs
+		}
+
+		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
+	},
+}
+
+var ChecksumVerifyCmd = &cobra.Command{
+	Use:   "checksum-verify [<local .path pack>] [<local .checksum path>]",
+	Short: "Verifies the integrity of a pack using its .checksum file",
+	// TODO: Long
+	Args:              cobra.MinimumNArgs(0),
+	PersistentPreRunE: configureInstaller,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) != 2 {
+			log.Error("Please provide path to pack and checksum file")
+			return errs.ErrIncorrectCmdArgs
+		}
+
+		return cryptography.VerifyChecksum(args[0], args[1])
+	},
+}

--- a/cmd/commands/checksum_test.go
+++ b/cmd/commands/checksum_test.go
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package commands_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
+)
+
+var checksumCreateCmdTests = []TestCase{
+	{
+		name:        "test different number of parameters",
+		args:        []string{"checksum-create"},
+		expectedErr: errors.New("accepts 1 arg(s), received 0"),
+	},
+	{
+		name:        "test creating checksum of unexisting pack",
+		args:        []string{"checksum-create", "DoesNotExist.Pack.1.2.3.pack"},
+		expectedErr: errs.ErrFileNotFound,
+	},
+	{
+		name:        "test using unexisting hash function",
+		args:        []string{"checksum-create", "Pack.1.2.3.pack", "-a", "sha1"},
+		expectedErr: errs.ErrInvalidHashFunction,
+		setUpFunc: func(t *TestCase) {
+			f, _ := os.Create("Pack.1.2.3.pack.sha256.checksum")
+			f.Close()
+		},
+		tearDownFunc: func() {
+			os.Remove("Pack.1.2.3.pack.sha256.checksum")
+		},
+	},
+}
+
+var checksumVerifyCmdTests = []TestCase{
+	{
+		name:        "test different number of parameters",
+		args:        []string{"checksum-verify"},
+		expectedErr: errors.New("accepts 2 arg(s), received 0"),
+	},
+	{
+		name:        "test verifying checksum of unexisting pack",
+		args:        []string{"checksum-verify", "DoesNotExist.Pack.1.2.3.pack", "DoesNotExist.Pack.1.2.3.pack.sha256.checksum"},
+		expectedErr: errs.ErrFileNotFound,
+		setUpFunc: func(t *TestCase) {
+			f, _ := os.Create("DoesNotExist.Pack.1.2.3.pack.sha256.checksum")
+			f.Close()
+		},
+		tearDownFunc: func() {
+			os.Remove("DoesNotExist.Pack.1.2.3.pack.sha256.checksum")
+		},
+	},
+	{
+		name:        "test verifying checksum of unexisting checksum file",
+		args:        []string{"checksum-verify", "Pack.1.2.3.pack", "DoesNotExist.Pack.1.2.3.pack.sha256.checksum"},
+		expectedErr: errs.ErrFileNotFound,
+		setUpFunc: func(t *TestCase) {
+			f, _ := os.Create("Pack.1.2.3.pack.sha256.checksum")
+			f.Close()
+		},
+		tearDownFunc: func() {
+			os.Remove("Pack.1.2.3.pack.sha256.checksum")
+		},
+	},
+}
+
+func TestChecksumCreateCmd(t *testing.T) {
+	runTests(t, checksumCreateCmdTests)
+}
+
+func TestChecksumVerifyCmd(t *testing.T) {
+	runTests(t, checksumVerifyCmdTests)
+}

--- a/cmd/commands/index.go
+++ b/cmd/commands/index.go
@@ -4,6 +4,9 @@
 package commands
 
 import (
+	"os"
+	"runtime"
+
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -13,11 +16,10 @@ import (
 var overwrite bool
 
 var IndexCmd = &cobra.Command{
-	Deprecated: "Consider running `cpackget update-index` instead",
-	Use:        "index <index url>",
-	Short:      "Updates public index",
-	Long: `Updates the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the file specified by the given url.
-If there's already an index file, cpackget won't overwrite it. Use "-f" to do so.`,
+	Deprecated:        "Consider running `cpackget update-index` instead",
+	Use:               "index <index url>",
+	Short:             "Updates public index",
+	Long:              getLongIndexDescription(),
 	PersistentPreRunE: configureInstaller,
 	Args:              cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -25,6 +27,18 @@ If there's already an index file, cpackget won't overwrite it. Use "-f" to do so
 		indexPath := args[0]
 		return installer.UpdatePublicIndex(indexPath, overwrite, true)
 	},
+}
+
+// getLongIndexDescription prints a "Windows friendly" long description,
+// using the correct path slashes
+func getLongIndexDescription() string {
+	if runtime.GOOS == "windows" {
+		return `Updates the public index in ` + os.Getenv("CMSIS_PACK_ROOT") + `\.Web\index.pidx using the file specified by the given url.
+If there's already an index file, cpackget won't overwrite it. Use "-f" to do so.`
+	} else {
+		return `Updates the public index in ` + os.Getenv("CMSIS_PACK_ROOT") + `/.Web/index.pidx using the file specified by the given url.
+If there's already an index file, cpackget won't overwrite it. Use "-f" to do so.`
+	}
 }
 
 func init() {

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -26,6 +26,8 @@ var AllCommands = []*cobra.Command{
 	RmCmd,
 	ListCmd,
 	UpdateIndexCmd,
+	ChecksumCreateCmd,
+	ChecksumVerifyCmd,
 }
 
 // createPackRoot is a flag that determines if the pack root should be created or not

--- a/cmd/commands/update_index.go
+++ b/cmd/commands/update_index.go
@@ -4,6 +4,9 @@
 package commands
 
 import (
+	"os"
+	"runtime"
+
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -15,16 +18,27 @@ var updateIndexCmdFlags struct {
 }
 
 var UpdateIndexCmd = &cobra.Command{
-	Use:   "update-index",
-	Short: "Update the public index",
-	Long: `Update the public index in CMSIS_PACK_ROOT/.Web/index.pidx using the URL in <url> tag inside index.pidx.
-By default it will also check if all PDSC files under .Web/ need update as well. This can be disabled via the "--sparse" flag.`,
+	Use:               "update-index",
+	Short:             "Update the public index",
+	Long:              getLongUpdateDescription(),
 	PersistentPreRunE: configureInstaller,
 	Args:              cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Updating public index")
 		return installer.UpdatePublicIndex("", true, updateIndexCmdFlags.sparse)
 	},
+}
+
+// getLongUpdateDescription prints a "Windows friendly" long description,
+// using the correct path slashes
+func getLongUpdateDescription() string {
+	if runtime.GOOS == "windows" {
+		return `Updates the public index in ` + os.Getenv("CMSIS_PACK_ROOT") + `\.Web\index.pidx using the URL in <url> tag inside index.pidx.
+By default it will also check if all PDSC files under .Web/ need update as well. This can be disabled via the "--sparse" flag.`
+	} else {
+		return `Updates the public index in ` + os.Getenv("CMSIS_PACK_ROOT") + `/.Web/index.pidx using the URL in <url> tag inside index.pidx.
+By default it will also check if all PDSC files under .Web/ need update as well. This can be disabled via the "--sparse" flag.`
+	}
 }
 
 func init() {

--- a/cmd/cryptography/checksum.go
+++ b/cmd/cryptography/checksum.go
@@ -66,10 +66,6 @@ func getChecksumList(baseDir string, filePathList []string, hashFunction string)
 }
 
 func GenerateChecksum(sourcePack, destinationDir, hashFunction string) error {
-	// Use default Cryptographic Hash Function if none is provided
-	if hashFunction == "" {
-		hashFunction = Hashes[0]
-	}
 	if !isValidHash(hashFunction) {
 		return errs.ErrInvalidHashFunction
 	}

--- a/cmd/cryptography/checksum.go
+++ b/cmd/cryptography/checksum.go
@@ -16,6 +16,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// isValidHash returns whether a hash function is
+// supported or not.
 func isValidHash(hashFunction string) bool {
 	for _, h := range Hashes {
 		if h == hashFunction {
@@ -25,9 +27,8 @@ func isValidHash(hashFunction string) bool {
 	return false
 }
 
-// GetChecksumList receives a list of file paths and returns
-// their hashed content using either a specified function or
-// the default one
+// getChecksumList computes the digests of a pack according
+// to the specified hash function.
 func getChecksumList(sourcePack, hashFunction string) (map[string]string, error) {
 	var h hash.Hash
 	switch hashFunction {
@@ -62,6 +63,7 @@ func getChecksumList(sourcePack, hashFunction string) (map[string]string, error)
 	return digests, nil
 }
 
+// GenerateChecksum creates a .checksum file for a pack.
 func GenerateChecksum(sourcePack, destinationDir, hashFunction string) error {
 	if !isValidHash(hashFunction) {
 		return errs.ErrInvalidHashFunction
@@ -107,6 +109,8 @@ func GenerateChecksum(sourcePack, destinationDir, hashFunction string) error {
 	return nil
 }
 
+// VerifyChecksum validates the contents of a pack
+// according to a provided .checksum file.
 func VerifyChecksum(sourcePack, sourceChecksum string) error {
 	if !utils.FileExists(sourcePack) {
 		log.Errorf("\"%s\" does not exist", sourcePack)

--- a/cmd/cryptography/checksum.go
+++ b/cmd/cryptography/checksum.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"hash"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,15 +47,9 @@ func getChecksumList(sourcePack, hashFunction string) (map[string]string, error)
 		if err != nil {
 			return nil, err
 		}
-		// Avoid Potential DoS vulnerability via decompression bomb
-		for {
-			_, err = io.CopyN(h, reader, 1024)
-			if err != nil {
-				if err == io.EOF {
-					break
-				}
-				return nil, err
-			}
+		_, err = utils.SecureCopy(h, reader)
+		if err != nil {
+			return nil, err
 		}
 		digests[file.Name] = fmt.Sprintf("%x", h.Sum(nil))
 	}

--- a/cmd/cryptography/checksum.go
+++ b/cmd/cryptography/checksum.go
@@ -1,0 +1,246 @@
+package cryptography
+
+import (
+	"archive/zip"
+	"bufio"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
+	"github.com/open-cmsis-pack/cpackget/cmd/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type checksum struct {
+	hashFunction, digest, filename string
+}
+
+func isValidHash(hashFunction string) bool {
+	valid := false
+	for _, h := range Hashes {
+		if h == hashFunction {
+			valid = true
+		}
+	}
+	return valid
+}
+
+// GetChecksumList receives a list of file paths and returns
+// their hashed content using either a specified function or
+// the default one
+func getChecksumList(baseDir string, filePathList []string, hashFunction string) ([]checksum, error) {
+	digests := make([]checksum, len(filePathList))
+	for i := 0; i < len(filePathList); i++ {
+		if utils.DirExists(filePathList[i]) {
+			continue
+		}
+		f, err := os.Open(filePathList[i])
+		if err != nil {
+			return []checksum{}, err
+		}
+		defer f.Close()
+
+		var h hash.Hash
+		switch hashFunction {
+		case "sha256":
+			h = sha256.New()
+			digests[i].hashFunction = "sha256"
+		default:
+			h = sha256.New()
+			digests[i].hashFunction = "sha256"
+		}
+
+		if _, err := io.Copy(h, f); err != nil {
+			return []checksum{}, err
+		}
+
+		digests[i].digest = fmt.Sprintf("%x", h.Sum(nil))
+		digests[i].filename = strings.ReplaceAll(filePathList[i], baseDir, "")
+	}
+	return digests, nil
+}
+
+func GenerateChecksum(sourcePack, destinationDir, hashFunction string) error {
+	// Use default Cryptographic Hash Function if none is provided
+	if hashFunction == "" {
+		hashFunction = Hashes[0]
+	}
+	if !isValidHash(hashFunction) {
+		return errs.ErrInvalidHashFunction
+	}
+
+	if !utils.FileExists(sourcePack) {
+		log.Errorf("\"%s\" is not a valid .pack", sourcePack)
+		return errs.ErrFileNotFound
+	}
+
+	// Checksum file path defaults to the .pack's location
+	base := ""
+	if destinationDir == "" {
+		base = filepath.Clean(strings.TrimSuffix(sourcePack, filepath.Ext(sourcePack)))
+	} else {
+		if !utils.DirExists(destinationDir) {
+			log.Errorf("\"%s\" is not a valid directory", destinationDir)
+			return errs.ErrDirectoryNotFound
+		}
+		base = filepath.Clean(destinationDir) + string(filepath.Separator) + strings.TrimSuffix(string(filepath.Base(sourcePack)), ".pack")
+	}
+	checksumFilename := base + "." + strings.Replace(hashFunction, "-", "", -1) + ".checksum"
+
+	if utils.FileExists(checksumFilename) {
+		log.Errorf("\"%s\" already exists, choose a diferent path", checksumFilename)
+		return errs.ErrPathAlreadyExists
+	}
+
+	// Unpack it to the same directory as the .pack
+	packDir := strings.TrimSuffix(sourcePack, filepath.Ext(sourcePack)) + string(os.PathSeparator)
+	if utils.DirExists(packDir) {
+		log.Errorf("pack was already extracted to \"%s\"", packDir)
+		return errs.ErrPathAlreadyExists
+	}
+
+	zipReader, err := zip.OpenReader(sourcePack)
+	if err != nil {
+		log.Errorf("can't decompress \"%s\": %s", sourcePack, err)
+		return errs.ErrFailedDecompressingFile
+	}
+	var packFileList []string
+	for _, file := range zipReader.File {
+		if err := utils.SecureInflateFile(file, packDir, ""); err != nil {
+			if err == errs.ErrTerminatedByUser {
+				log.Infof("aborting pack extraction. Removing \"%s\"", packDir)
+				return os.RemoveAll(packDir)
+			}
+			return err
+		}
+		packFileList = append(packFileList, filepath.Join(filepath.Clean(packDir), filepath.Clean(file.Name)))
+	}
+
+	digests, err := getChecksumList(packDir, packFileList, hashFunction)
+	if err != nil {
+		return err
+	}
+
+	out, err := os.Create(checksumFilename)
+	if err != nil {
+		log.Error(err)
+		return errs.ErrFailedCreatingFile
+	}
+	defer out.Close()
+	for i := 0; i < len(digests); i++ {
+		_, err := out.Write([]byte(digests[i].digest + " " + digests[i].filename + "\n"))
+		if err != nil {
+			return err
+		}
+	}
+	// Cleanup extracted pack
+	log.Debugf("deleting \"%s\"", packDir)
+	if err := os.RemoveAll(packDir); err != nil {
+		return err
+	}
+	return nil
+}
+
+func VerifyChecksum(sourcePack, checksum string) error {
+	if !utils.FileExists(sourcePack) {
+		log.Errorf("\"%s\" is not a valid .pack", sourcePack)
+		return errs.ErrFileNotFound
+	}
+	if !utils.FileExists(checksum) {
+		log.Errorf("\"%s\" does not exist", checksum)
+		return errs.ErrFileNotFound
+	}
+	hashAlgorithm := filepath.Ext(strings.Split(checksum, ".checksum")[0])[1:]
+	if !isValidHash(hashAlgorithm) {
+		log.Errorf("\"%s\" is not a valid .checksum file (correct format is [<pack>].[<hash-algorithm>].checksum). Please confirm if the algorithm is supported.", checksum)
+		return errs.ErrInvalidHashFunction
+	}
+
+	// Unpack it to the same directory as the .pack
+	packDir := strings.TrimSuffix(sourcePack, filepath.Ext(sourcePack)) + string(os.PathSeparator)
+	if utils.DirExists(packDir) {
+		log.Errorf("pack was already extracted to \"%s\"", packDir)
+		return errs.ErrPathAlreadyExists
+	}
+
+	zipReader, err := zip.OpenReader(sourcePack)
+	if err != nil {
+		log.Errorf("can't decompress \"%s\": %s", sourcePack, err)
+		return errs.ErrFailedDecompressingFile
+	}
+	var packFileList []string
+	for _, file := range zipReader.File {
+		if err := utils.SecureInflateFile(file, packDir, ""); err != nil {
+			if err == errs.ErrTerminatedByUser {
+				log.Infof("aborting pack extraction. Removing \"%s\"", packDir)
+				return os.RemoveAll(packDir)
+			}
+			return err
+		}
+		packFileList = append(packFileList, filepath.Join(filepath.Clean(packDir), filepath.Clean(file.Name)))
+	}
+
+	// Calculate pack digests
+	digests, err := getChecksumList(packDir, packFileList, hashAlgorithm)
+	if err != nil {
+		return err
+	}
+	// Compare with target checksum file
+	checksumFile, err := os.Open(checksum)
+	if err != nil {
+		return err
+	}
+	defer checksumFile.Close()
+
+	scanner := bufio.NewScanner(checksumFile)
+	linesRead := 0
+	failure := false
+	for scanner.Scan() {
+		// They might not be in the same order
+		if scanner.Text() == "" {
+			continue
+		}
+		targetDigest := strings.Split(scanner.Text(), " ")[0]
+		targetFile := strings.Split(scanner.Text(), " ")[1]
+		// The checksum file might not have the same order
+		fileMatched := false
+		for i := 0; i < len(digests); i++ {
+			if digests[i].filename == targetFile {
+				if digests[i].digest != targetDigest {
+					log.Debugf("%s != %s", digests[i].digest, targetDigest)
+					log.Errorf("%s: computed checksum did NOT match", targetFile)
+					failure = true
+				}
+				fileMatched = true
+			}
+		}
+		// Make sure all files match
+		if !fileMatched {
+			log.Errorf("file \"%s\" was not found in the provided checksum file", targetFile)
+			return errs.ErrCorruptPack
+		}
+		linesRead++
+	}
+
+	// Cleanup extracted pack
+	log.Debugf("deleting \"%s\"", packDir)
+	if err := os.RemoveAll(packDir); err != nil {
+		return err
+	}
+
+	if linesRead != len(digests) {
+		log.Errorf("provided checksum file lists %d files, but pack contains %d files", linesRead, len(digests))
+		return errs.ErrCorruptPack
+	}
+	if failure {
+		return errs.ErrCorruptPack
+	}
+
+	log.Info("pack integrity verified, all checksums match.")
+	return nil
+}

--- a/cmd/cryptography/checksum.go
+++ b/cmd/cryptography/checksum.go
@@ -21,13 +21,12 @@ type checksum struct {
 }
 
 func isValidHash(hashFunction string) bool {
-	valid := false
 	for _, h := range Hashes {
 		if h == hashFunction {
-			valid = true
+			return true
 		}
 	}
-	return valid
+	return false
 }
 
 // GetChecksumList receives a list of file paths and returns

--- a/cmd/cryptography/checksum.go
+++ b/cmd/cryptography/checksum.go
@@ -70,7 +70,7 @@ func GenerateChecksum(sourcePack, destinationDir, hashFunction string) error {
 	}
 
 	if !utils.FileExists(sourcePack) {
-		log.Errorf("\"%s\" is not a valid .pack", sourcePack)
+		log.Errorf("\"%s\" does not exist", sourcePack)
 		return errs.ErrFileNotFound
 	}
 
@@ -143,7 +143,7 @@ func GenerateChecksum(sourcePack, destinationDir, hashFunction string) error {
 
 func VerifyChecksum(sourcePack, checksum string) error {
 	if !utils.FileExists(sourcePack) {
-		log.Errorf("\"%s\" is not a valid .pack", sourcePack)
+		log.Errorf("\"%s\" does not exist", sourcePack)
 		return errs.ErrFileNotFound
 	}
 	if !utils.FileExists(checksum) {

--- a/cmd/cryptography/const.go
+++ b/cmd/cryptography/const.go
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package cryptography
+
+// Hashes is the list of supported Cryptographic Hash Functions used for the checksum feature
+var Hashes = [1]string{"sha256"}

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -28,6 +28,7 @@ var (
 	ErrPackNotPurgeable      = errors.New("pack not purgeable")
 	ErrPdscEntryExists       = errors.New("pdsc already in index")
 	ErrPdscEntryNotFound     = errors.New("pdsc not found in index")
+	ErrEula                  = errors.New("user does not agree with the pack's license")
 	ErrExtractEula           = errors.New("user wants to extract embedded license only")
 	ErrLicenseNotFound       = errors.New("embedded license not found")
 	ErrPackRootNotFound      = errors.New("no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option -R/--pack-root string")

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -46,8 +46,13 @@ var (
 	ErrFailedCreatingDirectory   = errors.New("fail to create directory")
 	ErrFileNotFound              = errors.New("file not found")
 	ErrDirectoryNotFound         = errors.New("directory not found")
+	ErrPathAlreadyExists         = errors.New("path already exists")
 	ErrCopyingEqualPaths         = errors.New("failed copying files: source is the same as destination")
 	ErrMovingEqualPaths          = errors.New("failed moving files: source is the same as destination")
+
+	// Cryptography errors
+	ErrCorruptPack         = errors.New("pack is corrupt, checksum verification failed")
+	ErrInvalidHashFunction = errors.New("provided hash function is not supported")
 
 	// Security errors
 	ErrInsecureZipFileName = errors.New("zip file contains insecure characters: ../")

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -52,8 +52,9 @@ var (
 	ErrMovingEqualPaths          = errors.New("failed moving files: source is the same as destination")
 
 	// Cryptography errors
-	ErrCorruptPack         = errors.New("pack is corrupt, checksum verification failed")
-	ErrInvalidHashFunction = errors.New("provided hash function is not supported")
+	ErrBadPackIntegrity     = errors.New("bad pack integrity")
+	ErrIntegrityCheckFailed = errors.New("checksum verification failed")
+	ErrInvalidHashFunction  = errors.New("provided hash function is not supported")
 
 	// Security errors
 	ErrInsecureZipFileName = errors.New("zip file contains insecure characters: ../")

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -28,7 +28,6 @@ var (
 	ErrPackNotPurgeable      = errors.New("pack not purgeable")
 	ErrPdscEntryExists       = errors.New("pdsc already in index")
 	ErrPdscEntryNotFound     = errors.New("pdsc not found in index")
-	ErrEula                  = errors.New("user does not agree with the pack's license")
 	ErrExtractEula           = errors.New("user wants to extract embedded license only")
 	ErrLicenseNotFound       = errors.New("embedded license not found")
 	ErrPackRootNotFound      = errors.New("no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option -R/--pack-root string")

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -256,8 +256,8 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 			}
 
 			if !ok {
-				log.Info("User does not agree with the pack's license")
-				return nil
+				log.Info("User does not agree with the pack's license, not installing it")
+				return errs.ErrEula
 			}
 		} else {
 			// Explicitly inform the user that license has been agreed

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -256,7 +256,8 @@ func (p *PackType) install(installation *PacksInstallationType, checkEula bool) 
 			}
 
 			if !ok {
-				return errs.ErrEula
+				log.Info("User does not agree with the pack's license")
+				return nil
 			}
 		} else {
 			// Explicitly inform the user that license has been agreed

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -67,6 +67,10 @@ func AddPack(packPath string, checkEula, extractEula bool, forceReinstall bool) 
 	ui.Extract = extractEula
 
 	if err = pack.install(Installation, checkEula || extractEula); err != nil {
+		// Just for internal purposes, is not presented as an error to the user
+		if err == errs.ErrEula {
+			return nil
+		}
 		if dropPreInstalled {
 			log.Error("Error installing pack, reverting temporary pack to original state")
 			// Make sure the original directory doesn't exist to avoid moving errors

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -390,30 +390,6 @@ func TestAddPack(t *testing.T) {
 		})
 	})
 
-	t.Run("test installing pack with license disagreed", func(t *testing.T) {
-		localTestingDir := "test-add-pack-with-license-disagreed"
-		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
-
-		packPath := packWithLicense
-
-		info, err := utils.ExtractPackInfo(packPath)
-		assert.Nil(err)
-
-		// Should NOT be installed if license is not agreed
-		ui.LicenseAgreed = &ui.Disagreed
-		err = installer.AddPack(packPath, CheckEula, !ExtractEula, !ForceReinstall)
-
-		// Sanity check
-		assert.NotNil(err)
-		assert.Equal(errs.ErrEula, err)
-		assert.False(utils.FileExists(installer.Installation.PackIdx))
-
-		// Check in installer internals
-		pack := packInfoToType(info)
-		assert.False(installer.Installation.PackIsInstalled(pack))
-	})
-
 	t.Run("test installing pack with license agreed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-agreed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -390,6 +390,29 @@ func TestAddPack(t *testing.T) {
 		})
 	})
 
+	t.Run("test installing pack with license disagreed", func(t *testing.T) {
+		localTestingDir := "test-add-pack-with-license-disagreed"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		defer os.RemoveAll(localTestingDir)
+
+		packPath := packWithLicense
+
+		info, err := utils.ExtractPackInfo(packPath)
+		assert.Nil(err)
+
+		// Should NOT be installed if license is not agreed
+		ui.LicenseAgreed = &ui.Disagreed
+		err = installer.AddPack(packPath, CheckEula, !ExtractEula, !ForceReinstall)
+
+		// Sanity check
+		assert.Nil(err)
+		assert.False(utils.FileExists(installer.Installation.PackIdx))
+
+		// Check in installer internals
+		pack := packInfoToType(info)
+		assert.False(installer.Installation.PackIsInstalled(pack))
+	})
+
 	t.Run("test installing pack with license agreed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-agreed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))


### PR DESCRIPTION
This PR adds a "cryptography" module in order to support more advanced security features, such as integrity checking, and later on, digitally Signed Packs. The implementation is based on the ongoing discussion for a Signed Packs feature, started in #8. Checksum support has also been requested before (#91).

Currently only the "sha256" digest is supported, which is the industry standard for most cases. The new commands are:

* `cpackget checksum-create` takes a local .pack and creates a .checksum file, similar to the typical digest files (like .sha256). It contains a list of all the pack files and their digest, whose cryptographic hash function is provided in the filename (e.g: `TheVendor.ThePack.1.2.3.sha256.checksum`).
* `cpackget-verify` takes that .checksum file and verifies the integrity of a local .pack, assuming it was generated with the other command.

It also includes small fixes regarding issues #85 and #93.