### PR TITLE
Make Pack Root Read Only

### DIFF
--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -84,6 +84,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 
 		log.Debugf("Specified packs %v", args)
 		var lastErr error
+		installer.UnlockPackRoot()
 		for _, packPath := range args {
 			var err error
 			if filepath.Ext(packPath) == ".pdsc" {
@@ -100,6 +101,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 				}
 			}
 		}
+		installer.LockPackRoot()
 
 		return lastErr
 	},

--- a/cmd/commands/index.go
+++ b/cmd/commands/index.go
@@ -25,7 +25,10 @@ var IndexCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Updating index %v", args)
 		indexPath := args[0]
-		return installer.UpdatePublicIndex(indexPath, overwrite, true)
+		installer.UnlockPackRoot()
+		err := installer.UpdatePublicIndex(indexPath, overwrite, true)
+		installer.LockPackRoot()
+		return err
 	},
 }
 

--- a/cmd/commands/index_test.go
+++ b/cmd/commands/index_test.go
@@ -21,6 +21,7 @@ var indexCmdTests = []TestCase{
 	{
 		name:        "test with no packroot configured",
 		args:        []string{"index", "index.pidx"},
+		env:         map[string]string{"CMSIS_PACK_ROOT": ""},
 		expectedErr: errs.ErrPackRootNotFound,
 	},
 	{
@@ -69,9 +70,8 @@ var initCmdTests = []TestCase{
 		expectedErr: errors.New("accepts 1 arg(s), received 0"),
 	},
 	{
-		name:           "test create using an index.pidx",
-		args:           []string{"init"},
-		createPackRoot: true,
+		name: "test create using an index.pidx",
+		args: []string{"init"},
 		setUpFunc: func(t *TestCase) {
 			server := NewServer()
 			t.args = append(t.args, server.URL()+"index.pidx")

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -32,6 +32,9 @@ The index-url is mandatory. Ex "cpackget init --pack-root path/to/mypackroot htt
 			return err
 		}
 
-		return installer.UpdatePublicIndex(indexPath, true, true)
+		installer.UnlockPackRoot()
+		err = installer.UpdatePublicIndex(indexPath, true, true)
+		installer.LockPackRoot()
+		return err
 	},
 }

--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -78,6 +78,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 
 		log.Debugf("Specified packs %v", args)
 		var firstError error
+		installer.UnlockPackRoot()
 		for _, packPath := range args {
 			if err := installer.AddPack(packPath, !skipEula, extractEula, forceReinstall); err != nil {
 				if firstError == nil {
@@ -89,6 +90,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 				}
 			}
 		}
+		installer.LockPackRoot()
 
 		if firstError == nil {
 			return nil
@@ -109,6 +111,8 @@ Cache files (i.e. under CMSIS_PACK_ROOT/.Download/) are *NOT* removed. If cache 
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Removing %v", args)
+		installer.UnlockPackRoot()
+		defer installer.LockPackRoot()
 		for _, packPath := range args {
 			if err := installer.RemovePack(packPath, purge); err != nil {
 				return err

--- a/cmd/commands/pdsc.go
+++ b/cmd/commands/pdsc.go
@@ -24,6 +24,8 @@ cpackget will add the pdsc entry to CMSIS_PACK_ROOT/.Local/local_repository.pidx
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Adding pdsc")
+		installer.UnlockPackRoot()
+		defer installer.LockPackRoot()
 		for _, pdscPath := range args {
 			if err := installer.AddPdsc(pdscPath); err != nil {
 				return err
@@ -42,6 +44,8 @@ cpackget will remove the pdsc entry from CMSIS_PACK_ROOT/.Local/local_repository
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Info("Removing pdsc")
+		installer.UnlockPackRoot()
+		defer installer.LockPackRoot()
 		for _, pdscPath := range args {
 			if err := installer.RemovePdsc(pdscPath); err != nil {
 				return err

--- a/cmd/commands/rm.go
+++ b/cmd/commands/rm.go
@@ -52,6 +52,7 @@ please use "--purge".`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Removing %v", args)
 		var lastErr error
+		installer.UnlockPackRoot()
 		for _, packPath := range args {
 			var err error
 			if filepath.Ext(packPath) == ".pdsc" {
@@ -71,6 +72,7 @@ please use "--purge".`,
 
 			}
 		}
+		installer.LockPackRoot()
 
 		return lastErr
 	},

--- a/cmd/commands/update_index.go
+++ b/cmd/commands/update_index.go
@@ -25,7 +25,10 @@ var UpdateIndexCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		log.Infof("Updating public index")
-		return installer.UpdatePublicIndex("", true, updateIndexCmdFlags.sparse)
+		installer.UnlockPackRoot()
+		err := installer.UpdatePublicIndex("", true, updateIndexCmdFlags.sparse)
+		installer.LockPackRoot()
+		return err
 	},
 }
 

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -38,7 +38,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with bad name", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-bad-name"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := malformedPackName
 
@@ -55,8 +56,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack previously installed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-already-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
 		addPack(t, packPath, ConfigType{
@@ -76,7 +78,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test force-reinstalling a pack not yet installed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-force-reinstall-not-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
 		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall)
@@ -90,7 +93,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test force-reinstalling an installed pack", func(t *testing.T) {
 		localTestingDir := "test-add-pack-force-reinstall-already-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packToReinstall
 		addPack(t, packPath, ConfigType{})
@@ -106,7 +110,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test force-reinstalling a pack with a user interruption", func(t *testing.T) {
 		localTestingDir := "test-add-pack-force-reinstall-user-interruption"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packToReinstall
 		addPack(t, packPath, ConfigType{})
@@ -131,7 +136,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing local pack that does not exist", func(t *testing.T) {
 		localTestingDir := "test-add-local-pack-that-does-not-exist"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packThatDoesNotExist
 
@@ -148,7 +154,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing remote pack that does not exist", func(t *testing.T) {
 		localTestingDir := "test-add-remote-pack-that-does-not-exist"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		notFoundServer := NewServer()
 
@@ -167,7 +174,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with corrupt zip file", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-corrupt-zip"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithCorruptZip
 
@@ -184,7 +192,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with bad URL format", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-malformed-url"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithMalformedURL
 
@@ -201,7 +210,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with no PDSC file inside", func(t *testing.T) {
 		localTestingDir := "test-add-pack-without-pdsc-file"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithoutPdscFileInside
 
@@ -218,8 +228,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack that has problems with its directory", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-unaccessible-directory"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
 
@@ -238,8 +249,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with tainted compressed files", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-tainted-compressed-files"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithTaintedCompressedFiles
 
@@ -256,7 +268,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with version not present in the pdsc file", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-version-not-present-in-the-pdsc-file"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := pack123MissingVersion
 
@@ -273,7 +286,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack with version not the latest in the pdsc file", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-version-not-the-latest-in-the-pdsc-file"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := pack123VersionNotLatest
 
@@ -291,8 +305,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing public pack via local file", func(t *testing.T) {
 		localTestingDir := "test-add-public-local-pack"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
 		addPack(t, packPath, ConfigType{
@@ -303,8 +318,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing public pack via remote file", func(t *testing.T) {
 		localTestingDir := "test-add-public-remote-pack"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		zipContent, err := ioutil.ReadFile(publicRemotePack123)
 		assert.Nil(err)
@@ -323,8 +339,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing non-public pack via local file", func(t *testing.T) {
 		localTestingDir := "test-add-non-public-local-pack"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := nonPublicLocalPack123
 		addPack(t, packPath, ConfigType{
@@ -335,8 +352,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing non-public pack via remote file", func(t *testing.T) {
 		localTestingDir := "test-add-non-public-remote-pack"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := nonPublicRemotePack123
 		addPack(t, packPath, ConfigType{
@@ -348,7 +366,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing public pack retrieving pdsc file", func(t *testing.T) {
 		localTestingDir := "test-add-public-pack-retrieving-pdsc-file"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
 		packInfo, err := utils.ExtractPackInfo(packPath)
@@ -381,8 +400,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack without license", func(t *testing.T) {
 		localTestingDir := "test-add-pack-without-license"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := nonPublicLocalPack123
 		addPack(t, packPath, ConfigType{
@@ -393,7 +413,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with license disagreed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-disagreed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithLicense
 
@@ -416,7 +437,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with license agreed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-agreed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithLicense
 		ui.LicenseAgreed = &ui.Agreed
@@ -428,7 +450,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with rtf license agreed", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-rtf-license-agreed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithRTFLicense
 		ui.LicenseAgreed = &ui.Agreed
@@ -440,7 +463,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with license agreement skipped", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-skipped"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithLicense
 		addPack(t, packPath, ConfigType{
@@ -451,7 +475,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with license extracted", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-extracted"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithLicense
 
@@ -472,7 +497,8 @@ func TestAddPack(t *testing.T) {
 		// file is not there
 		localTestingDir := "test-add-pack-with-missing-license"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithMissingLicense
 
@@ -495,7 +521,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with missing license extracted", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-license-extracted"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithMissingLicense
 
@@ -514,7 +541,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack within subfolder", func(t *testing.T) {
 		localTestingDir := "test-add-pack-within-subfolder"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithSubFolder
 		addPack(t, packPath, ConfigType{})
@@ -523,7 +551,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack within too many subfolders", func(t *testing.T) {
 		localTestingDir := "test-add-pack-within-too-many-subfolder"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithSubSubFolder
 		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall)
@@ -540,7 +569,8 @@ func TestAddPack(t *testing.T) {
 		t.Run("test installing pack with pack id pdsc file not found "+packPath, func(t *testing.T) {
 			localTestingDir := "test-add-pack-with-pack-id-pdsc-file-not-found-" + safePackPath
 			assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-			defer os.RemoveAll(localTestingDir)
+			installer.UnlockPackRoot()
+			defer removePackRoot(localTestingDir)
 
 			// Fake public index server
 			publicIndexServer := NewServer()
@@ -567,7 +597,8 @@ func TestAddPack(t *testing.T) {
 		t.Run("test installing pack with pack id version not found "+packPath, func(t *testing.T) {
 			localTestingDir := "test-add-pack-with-pack-id-version-not-found-" + safePackPath
 			assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-			defer os.RemoveAll(localTestingDir)
+			installer.UnlockPackRoot()
+			defer removePackRoot(localTestingDir)
 
 			packInfo, err := utils.ExtractPackInfo(packPath)
 			assert.Nil(err)
@@ -588,7 +619,8 @@ func TestAddPack(t *testing.T) {
 		t.Run("test installing pack with pack id using release url"+packPath, func(t *testing.T) {
 			localTestingDir := "test-add-pack-with-pack-id-using-release-url" + safePackPath
 			assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-			defer os.RemoveAll(localTestingDir)
+			installer.UnlockPackRoot()
+			defer removePackRoot(localTestingDir)
 
 			// Prep pack info
 			packInfo, err := utils.ExtractPackInfo(packPath)
@@ -630,7 +662,8 @@ func TestAddPack(t *testing.T) {
 		t.Run("test installing pack with pack id using pdsc url "+packPath, func(t *testing.T) {
 			localTestingDir := "test-add-pack-with-pack-id-using-pdsc-url-" + safePackPath
 			assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-			defer os.RemoveAll(localTestingDir)
+			installer.UnlockPackRoot()
+			defer removePackRoot(localTestingDir)
 
 			// Prep pack info
 			packInfo, err := utils.ExtractPackInfo(packPath)
@@ -671,7 +704,8 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing pack with pack id using pdsc url when version is not the latest in index.pidx", func(t *testing.T) {
 		localTestingDir := "test-add-pack-with-pack-id-using-pdsc-url-version-not-the-latest"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Prep pack info
 		packPath := publicLocalPack123
@@ -717,8 +751,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing non-public pack via packID", func(t *testing.T) {
 		localTestingDir := "test-add-non-public-local-packid"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		pack123Path := nonPublicLocalPack123
 		pack124Path := nonPublicLocalPack124
@@ -755,6 +790,7 @@ func TestAddPack(t *testing.T) {
 
 		// Tweak the URL to retrieve version 1.2.3 and inject the 1.2.3 tag
 		pdscXML := xml.NewPdscXML(filepath.Join(installer.Installation.LocalDir, pack124.PdscFileName()))
+		utils.UnsetReadOnly(pdscXML.FileName)
 		assert.Nil(pdscXML.Read())
 		pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, xml.ReleaseTag{Version: "1.2.3"})
 		pdscXML.URL = server.URL()
@@ -768,8 +804,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack that got cancelled during download", func(t *testing.T) {
 		localTestingDir := "test-add-pack-cancelled-during-download"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		// Fake a user termination request
 		utils.ShouldAbortFunction = func() bool {
@@ -803,8 +840,9 @@ func TestAddPack(t *testing.T) {
 	t.Run("test installing a pack that got cancelled during extraction", func(t *testing.T) {
 		localTestingDir := "test-add-cancelled-during-extraction"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		// Fake a user termination request
 		skipAbortingOnPdscCopy := -1
@@ -853,7 +891,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-version-new-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -886,7 +925,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-version-none-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -927,7 +967,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-version-older-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -953,6 +994,7 @@ func TestAddPack(t *testing.T) {
 
 		// Inject URL into pdsc
 		pdscXML := xml.NewPdscXML(packPdscFilePath)
+		utils.UnsetReadOnly(packPdscFilePath)
 		assert.Nil(pdscXML.Read())
 		pdscXML.URL = server.URL()
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
@@ -974,7 +1016,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-version-higher-latest"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -992,7 +1035,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-compatible-version-new-major-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1018,6 +1062,7 @@ func TestAddPack(t *testing.T) {
 
 		// Inject URL into pdsc
 		pdscXML := xml.NewPdscXML(packPdscFilePath)
+		utils.UnsetReadOnly(packPdscFilePath)
 		assert.Nil(pdscXML.Read())
 		pdscXML.URL = server.URL()
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
@@ -1038,7 +1083,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-compatible-none-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1079,7 +1125,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-compatible-version-older-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1105,6 +1152,7 @@ func TestAddPack(t *testing.T) {
 
 		// Inject URL into pdsc
 		pdscXML := xml.NewPdscXML(packPdscFilePath)
+		utils.UnsetReadOnly(packPdscFilePath)
 		assert.Nil(pdscXML.Read())
 		pdscXML.URL = server.URL()
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
@@ -1125,7 +1173,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-compatible-version-same-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1159,7 +1208,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-minimum-compatible-version-higher-latest"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1177,7 +1227,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-at-latest-version-none-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1218,7 +1269,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-at-latest-version-none-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1244,6 +1296,7 @@ func TestAddPack(t *testing.T) {
 
 		// Inject URL into pdsc
 		pdscXML := xml.NewPdscXML(packPdscFilePath)
+		utils.UnsetReadOnly(packPdscFilePath)
 		assert.Nil(pdscXML.Read())
 		pdscXML.URL = server.URL()
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
@@ -1264,7 +1317,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-pack-with-at-latest-version-latest-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Inject pdsc into .Web folder
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
@@ -1299,7 +1353,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-local-pack-with-minimum-version-new-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Install 1.2.2
 		addPack(t, publicLocalPack122, ConfigType{})
@@ -1321,6 +1376,7 @@ func TestAddPack(t *testing.T) {
 
 		// Inject URL and 1.2.4. release tag into pdsc
 		pdscXML := xml.NewPdscXML(packPdscFilePath)
+		utils.UnsetReadOnly(packPdscFilePath)
 		assert.Nil(pdscXML.Read())
 		pdscXML.URL = server.URL()
 		releaseTag := xml.ReleaseTag{Version: "1.2.4"}
@@ -1343,7 +1399,8 @@ func TestAddPack(t *testing.T) {
 
 		localTestingDir := "test-installing-local-pack-with-at-latest-version-matching-pre-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Install 1.2.4
 		addPack(t, publicLocalPack124, ConfigType{})

--- a/cmd/installer/root_pack_list_test.go
+++ b/cmd/installer/root_pack_list_test.go
@@ -29,7 +29,7 @@ var (
 func ExampleListInstalledPacks() {
 	localTestingDir := "test-list-empty-pack-root"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	defer removePackRoot(localTestingDir)
 
 	log.SetOutput(os.Stdout)
 	defer log.SetOutput(ioutil.Discard)
@@ -43,7 +43,7 @@ func ExampleListInstalledPacks() {
 func ExampleListInstalledPacks_emptyCache() {
 	localTestingDir := "test-list-empty-cache"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	defer removePackRoot(localTestingDir)
 
 	log.SetOutput(os.Stdout)
 	defer log.SetOutput(ioutil.Discard)
@@ -57,7 +57,7 @@ func ExampleListInstalledPacks_emptyCache() {
 func ExampleListInstalledPacks_emptyPublicIndex() {
 	localTestingDir := "test-list-empty-index"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	defer removePackRoot(localTestingDir)
 
 	log.SetOutput(os.Stdout)
 	defer log.SetOutput(ioutil.Discard)
@@ -75,7 +75,8 @@ func ExampleListInstalledPacks_emptyPublicIndex() {
 func ExampleListInstalledPacks_list() {
 	localTestingDir := "test-list-packs"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
@@ -111,7 +112,8 @@ func ExampleListInstalledPacks_list() {
 func ExampleListInstalledPacks_listCached() {
 	localTestingDir := "test-list-cached-packs"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
@@ -149,7 +151,8 @@ func TestListInstalledPacks(t *testing.T) {
 	t.Run("test listing all installed packs", func(t *testing.T) {
 		localTestingDir := "test-list-installed-packs"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 		assert.Nil(utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc")))
@@ -192,7 +195,8 @@ func TestListInstalledPacks(t *testing.T) {
 	t.Run("test listing local packs with updated version", func(t *testing.T) {
 		localTestingDir := "test-list-installed-local-packs-with-updated-version"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// This test checks that cpackget lists whatever the latest version is in the actual PDSC file
 		// for a local pack installed via PDSC
@@ -231,7 +235,8 @@ func TestListInstalledPacks(t *testing.T) {
 func ExampleListInstalledPacks_listMalformedInstalledPacks() {
 	localTestingDir := "test-list-malformed-installed-packs"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
@@ -268,7 +273,8 @@ func ExampleListInstalledPacks_listMalformedInstalledPacks() {
 func ExampleListInstalledPacks_filter() {
 	localTestingDir := "test-list-packs-filter"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
@@ -302,7 +308,8 @@ func ExampleListInstalledPacks_filter() {
 func ExampleListInstalledPacks_filterErrorPackages() {
 	localTestingDir := "test-list-filter-error-message"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
@@ -338,7 +345,8 @@ func ExampleListInstalledPacks_filterErrorPackages() {
 func ExampleListInstalledPacks_filterInvalidChars() {
 	localTestingDir := "test-list-filter-invalid-chars"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))
@@ -371,7 +379,8 @@ func ExampleListInstalledPacks_filterInvalidChars() {
 func ExampleListInstalledPacks_filteradditionalMessages() {
 	localTestingDir := "test-list-filter-additional-messages"
 	_ = installer.SetPackRoot(localTestingDir, CreatePackRoot)
-	defer os.RemoveAll(localTestingDir)
+	installer.UnlockPackRoot()
+	defer removePackRoot(localTestingDir)
 
 	pdscFilePath := strings.Replace(publicLocalPack123, ".1.2.3.pack", ".pdsc", -1)
 	_ = utils.CopyFile(pdscFilePath, filepath.Join(installer.Installation.WebDir, "TheVendor.PublicLocalPack.pdsc"))

--- a/cmd/installer/root_pack_rm_test.go
+++ b/cmd/installer/root_pack_rm_test.go
@@ -23,7 +23,8 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test removing a pack with malformed name", func(t *testing.T) {
 		localTestingDir := "test-remove-pack-with-bad-name"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.RemovePack("TheVendor.PackName.no-a-valid-version", false)
 
@@ -35,7 +36,8 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test removing a pack that is not installed", func(t *testing.T) {
 		localTestingDir := "test-remove-pack-not-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.RemovePack("TheVendor.PackName.1.2.3", false)
 
@@ -47,8 +49,9 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test remove a public pack that was added", func(t *testing.T) {
 		localTestingDir := "test-remove-public-pack-that-was-added"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack124
 		config := ConfigType{
@@ -72,8 +75,9 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test remove a non-public pack that was added", func(t *testing.T) {
 		localTestingDir := "test-remove-nonpublic-pack-that-was-added"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		packPath := nonPublicLocalPack123
 		config := ConfigType{
@@ -97,8 +101,9 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test remove version of a pack", func(t *testing.T) {
 		localTestingDir := "test-remove-version-of-a-pack"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		// Add a pack, add an updated version of the pack, then remove the first one
 		packPath := publicLocalPack123
@@ -116,8 +121,9 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test remove a pack then purge", func(t *testing.T) {
 		localTestingDir := "test-remove-a-pack-then-purge"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		// Add a pack, add an updated version of the pack, then remove the first one
 		packPath := publicLocalPack123
@@ -139,7 +145,8 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test purge a pack with license", func(t *testing.T) {
 		localTestingDir := "test-purge-pack-with-license"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := packWithLicense
 
@@ -170,8 +177,9 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test remove latest version", func(t *testing.T) {
 		localTestingDir := "test-remove-latest-versions"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		// Add a pack, add an updated version of the pack, then remove the first one
 		packPath := publicLocalPack123
@@ -189,7 +197,8 @@ func TestRemovePack(t *testing.T) {
 	t.Run("test remove public pack without pdsc file in .Web folder", func(t *testing.T) {
 		localTestingDir := "test-remove-public-pack-without-pdsc-in-web-folder"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
 		packInfo, err := utils.ExtractPackInfo(packPath)
@@ -212,23 +221,4 @@ func TestRemovePack(t *testing.T) {
 		// Assert that the file did not get created during the operation
 		assert.False(utils.FileExists(pdscFilePath))
 	})
-
-	// t.Run("test remove all versions at once", func(t *testing.T) {
-	// 	localTestingDir := "test-remove-all-versions-at-once"
-	// 	assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-	// 	installer.Installation.WebDir = filepath.Join(testDir, "public_index")
-	// 	defer os.RemoveAll(localTestingDir)
-
-	// 	// Add a pack, add an updated version of the pack, then remove the first one
-	// 	packPath := publicLocalPack123
-	// 	updatedPackPath := publicLocalPack124
-	// 	config := ConfigType{
-	// 		IsPublic: true,
-	// 	}
-	// 	addPack(t, packPath, config)
-	// 	addPack(t, updatedPackPath, config)
-
-	// 	// Remove latest pack (withVersion=false), i.e. path will be "TheVendor.PackName"
-	// 	removePack(t, packPath, false, IsPublic, true) // withVersion=false, purge=true
-	// })
 }

--- a/cmd/installer/root_pdsc_add_test.go
+++ b/cmd/installer/root_pdsc_add_test.go
@@ -23,7 +23,8 @@ func TestAddPdsc(t *testing.T) {
 	t.Run("test add pdsc with bad name", func(t *testing.T) {
 		localTestingDir := "test-add-pdsc-with-bad-name"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.AddPdsc(malformedPackName)
 		assert.Equal(errs.ErrBadPackName, err)
@@ -32,8 +33,9 @@ func TestAddPdsc(t *testing.T) {
 	t.Run("test add pdsc with bad local_repository.pidx", func(t *testing.T) {
 		localTestingDir := "test-add-pdsc-with-bad-local-repository"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		installer.Installation.LocalPidx = xml.NewPidxXML(badLocalRepositoryPidx)
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 
 		err := installer.AddPdsc(pdscPack123)
 		assert.NotNil(err)
@@ -43,7 +45,8 @@ func TestAddPdsc(t *testing.T) {
 	t.Run("test add a pdsc", func(t *testing.T) {
 		localTestingDir := "test-add-a-pdsc"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.AddPdsc(pdscPack123)
 
@@ -54,7 +57,8 @@ func TestAddPdsc(t *testing.T) {
 	t.Run("test add a pdsc already installed", func(t *testing.T) {
 		localTestingDir := "test-add-a-pdsc-already-installed"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.AddPdsc(pdscPack123)
 		assert.Nil(err)
@@ -66,7 +70,8 @@ func TestAddPdsc(t *testing.T) {
 	t.Run("test add new pdsc version", func(t *testing.T) {
 		localTestingDir := "test-add-new-pdsc-version"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.AddPdsc(pdscPack123)
 		assert.Nil(err)
@@ -78,7 +83,8 @@ func TestAddPdsc(t *testing.T) {
 	t.Run("test add new pdsc version with same path", func(t *testing.T) {
 		localTestingDir := "test-add-new-pdsc-version-same-path"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Work on a local copy of the file
 		pdscFileName := filepath.Base(pdscPack123)

--- a/cmd/installer/root_pdsc_rm_test.go
+++ b/cmd/installer/root_pdsc_rm_test.go
@@ -4,7 +4,6 @@
 package installer_test
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -20,7 +19,8 @@ func TestRemovePdsc(t *testing.T) {
 	t.Run("test remove pdsc with bad name", func(t *testing.T) {
 		localTestingDir := "test-remove-pdsc-with-bad-name"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.RemovePdsc(malformedPackName)
 		assert.NotNil(err)
@@ -30,7 +30,8 @@ func TestRemovePdsc(t *testing.T) {
 	t.Run("test remove a pdsc", func(t *testing.T) {
 		localTestingDir := "test-remove-pdsc"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Add it first
 		err := installer.AddPdsc(pdscPack123)
@@ -51,7 +52,8 @@ func TestRemovePdsc(t *testing.T) {
 	t.Run("test remove multiple pdscs using basename PDSC file name", func(t *testing.T) {
 		localTestingDir := "test-remove-multiple-pdscs-using-basename-pdsc-file-name"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Add it first
 		err := installer.AddPdsc(pdscPack123)
@@ -76,7 +78,8 @@ func TestRemovePdsc(t *testing.T) {
 	t.Run("test remove a pdsc using full path", func(t *testing.T) {
 		localTestingDir := "test-remove-pdsc-using-full-path"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Add it first
 		err := installer.AddPdsc(pdscPack123)
@@ -98,7 +101,8 @@ func TestRemovePdsc(t *testing.T) {
 	t.Run("test remove one pdsc using full path and leave others untouched", func(t *testing.T) {
 		localTestingDir := "test-remove-one-pdsc-using-full-path-and-leave-others-untouched"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		// Add it first
 		err := installer.AddPdsc(pdscPack123)
@@ -121,7 +125,8 @@ func TestRemovePdsc(t *testing.T) {
 	t.Run("test remove a pdsc that does not exist", func(t *testing.T) {
 		localTestingDir := "test-remove-pdsc-that-does-not-exist"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
-		defer os.RemoveAll(localTestingDir)
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
 
 		err := installer.RemovePdsc(shortenPackPath(pdscPack123, true))
 		assert.Equal(errs.ErrPdscEntryNotFound, err)

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -366,6 +366,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	// t.Run("test add http server index.pidx", func(t *testing.T) {
 	// 	localTestingDir := "test-add-http-server-index"
 	// 	assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+	installer.UnlockPackRoot()
 	// 	defer os.RemoveAll(localTestingDir)
 
 	// 	httpServer := httptest.NewServer(
@@ -386,6 +387,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test add not found remote index.pidx", func(t *testing.T) {
 		localTestingDir := "test-add-not-found-remote-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		server := NewServer()
@@ -401,6 +403,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test add malformed index.pidx", func(t *testing.T) {
 		localTestingDir := "test-add-malformed-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		indexContent, err := ioutil.ReadFile(malformedPublicIndex)
@@ -419,6 +422,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test add remote index.pidx", func(t *testing.T) {
 		localTestingDir := "test-add-remote-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		indexContent, err := ioutil.ReadFile(samplePublicIndex)
@@ -442,6 +446,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test add local file index.pidx", func(t *testing.T) {
 		localTestingDir := "test-add-local-file-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		indexContent, err := ioutil.ReadFile(samplePublicIndex)
@@ -460,6 +465,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test do not overwrite index.pidx", func(t *testing.T) {
 		localTestingDir := "test-do-not-overwrite-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		_ = utils.TouchFile(installer.Installation.PublicIndex)
@@ -479,6 +485,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test overwrite index.pidx", func(t *testing.T) {
 		localTestingDir := "test-overwrite-index"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		_ = utils.TouchFile(installer.Installation.PublicIndex)
@@ -503,6 +510,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test full update when sparse is false", func(t *testing.T) {
 		localTestingDir := "test-sparse-update"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
 		defer os.RemoveAll(localTestingDir)
 
 		// A non-sparse/full update should detect all
@@ -578,6 +586,11 @@ func checkPackRoot(t *testing.T, path string) {
 	assert.True(utils.DirExists(installer.Installation.LocalDir))
 }
 
+func removePackRoot(packRoot string) {
+	utils.UnsetReadOnlyR(packRoot)
+	os.RemoveAll(packRoot)
+}
+
 func TestSetPackRoot(t *testing.T) {
 
 	assert := assert.New(t)
@@ -600,7 +613,7 @@ func TestSetPackRoot(t *testing.T) {
 
 	t.Run("test initialize pack root", func(t *testing.T) {
 		localTestingDir := "valid-pack-root"
-		defer os.RemoveAll(localTestingDir)
+		defer removePackRoot(localTestingDir)
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
 
 		checkPackRoot(t, localTestingDir)

--- a/scripts/test-xmllint-localrepository
+++ b/scripts/test-xmllint-localrepository
@@ -23,8 +23,10 @@ cat <<PIDX >/tmp/index.pidx
 PIDX
 
 ./build/cpackget init /tmp/index.pidx
-./build/cpackget pdsc add testdata/devpack/1.2.3/TheVendor.DevPack.pdsc
+./build/cpackget add testdata/devpack/1.2.3/TheVendor.DevPack.pdsc
 
 xmllint --schema testdata/PackIndex.xsd $PACK_ROOT/.Local/local_repository.pidx --noout
+
+chmod -R +w $PACK_ROOT
 
 rm -rf $PACK_ROOT


### PR DESCRIPTION
Fixes: https://github.com/Open-CMSIS-Pack/cpackget/issues/56

This patch is quite big! It makes all files and directories under $CMSIS_PACK_ROOT Read-Only! The ONLY one exception for
this is the .Local/local_repository.pidx file, since it will be written over and over when other tools add more local packs into the repository.

I chose to do it all in a single commit in case this might cause some trouble with users not used to have all their files in read-only mode all the time. So if needed, this can be reverted in one go.