### PR TITLE
Arm64 linux builds and CICD support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,4 +23,6 @@ jobs:
           make build/cpackget
           make OS=windows ARCH=amd64 build/cpackget.exe
           make clean
-          make OS=darwin  ARCH=amd64 build/cpackget
+          make OS=darwin ARCH=amd64 build/cpackget
+          make clean
+          make OS=linux ARCH=arm64 build/cpackget

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-
   lint:
     name: Lint
     timeout-minutes: 10
@@ -67,7 +66,7 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest]
         go: [1.18.x]
-    name: '${{ matrix.platform }} | ${{ matrix.go }}'
+    name: "${{ matrix.platform }} | ${{ matrix.go }}"
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Check out repository code
@@ -79,3 +78,29 @@ jobs:
       - name: Unit testing
         run: |
           make coverage-check
+
+  test-arm64:
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        go: [1.18.x]
+        arch: [aarch64]
+        distro: [ubuntu_latest]
+    name: "${{ matrix.platform }} | ${{ matrix.go }} | ${{ matrix.arch }}"
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Unit testing
+        uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          env: |
+            GIT_DISCOVERY_ACROSS_FILESYSTEM: 1
+          install: |
+            apt-get update -qq -y
+            apt-get install -qq -y git make golang=2:1.18\~0ubuntu2
+          run: |
+            git clone https://github.com/$GITHUB_REPOSITORY -q
+            cd cpackget
+            git checkout $GITHUB_REF -q
+            make ARCH=arm64 GOOS=linux coverage-check

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ run:
 linters:
   disable-all: true # Disable defaults, then enable the ones we want
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
@@ -17,7 +16,6 @@ linters:
     # - structcheck https://github.com/golangci/golangci-lint/issues/2649
     - typecheck
     - unused
-    - varcheck
     # - bodyclose Disabled so concurrent GETs can happen
     - stylecheck
     - gosec

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,13 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     dir: cmd
+    ignore:
+      - goos: darwin
+        goarch: arm64
+      - goos: windows
+        goarch: arm64
 
 archives:
   - files:
@@ -26,5 +32,3 @@ archives:
     # You can also set it to a custom folder name (templating is supported).
     # Default is false.
     wrap_in_directory: true
-
-

--- a/cmd/commands/root_test.go
+++ b/cmd/commands/root_test.go
@@ -62,12 +62,6 @@ func (s *Server) AddRoute(route string, content []byte) {
 }
 
 // NewServer is a generic dev server that takes in a routes map and returns 404 if the route[path] is nil
-// Ex:
-// server := NewServer(map[string][]byte{
-// 	"*": []byte("Default content"),
-// 	"should-return-404": nil,
-// })
-//
 // Acessing server.URL should return "Default content"
 // Acessing server.URL + "/should-return-404" should return HTTP 404
 func NewServer() Server {

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 OS ?= $(shell uname)
 
 # Having this will allow CI scripts to build for many OS's and ARCH's
-ARCH := $(or $(ARCH),$(ARCH),amd64)
+ARCH := $(or $(ARCH),amd64)
 
 # Path to lint tool
 GOLINTER ?= golangci-lint
@@ -33,7 +33,8 @@ all:
 	@echo
 	@echo Build for different OS's and ARCH's by defining these variables. Ex:
 	@echo $$ make OS=windows ARCH=amd64 build/$(BIN_NAME).exe
-	@echo $$ make OS=darwin  ARCH=amd64 build/$(BIN_NAME)
+	@echo $$ make OS=darwin ARCH=amd64 build/$(BIN_NAME)
+	@echo $$ make OS=linux ARCH=arm64 build/$(BIN_NAME)
 	@echo
 	@echo Run tests
 	@echo $$ make test ARGS="<test args>"
@@ -69,7 +70,7 @@ format-check:
 
 .PHONY: test release config
 test: $(SOURCES)
-	cd cmd && go test $(ARGS) ./... -coverprofile ../cover.out
+	cd cmd && GOOS=$(OS) GOARCH=$(ARCH) go test $(ARGS) ./... -coverprofile ../cover.out
 
 test-all: format-check coverage-check lint
 
@@ -78,7 +79,7 @@ coverage-report: test
 
 coverage-check: test
 	@echo Checking if test coverage is above 90%
-	test `go tool cover -func cover.out | tail -1 | awk '{print ($$3 + 0)*10}'` -gt 900
+	test `go tool cover -func cover.out | tail -1 | awk '{print ($$3 + 0)*10}'` -ge 900
 
 test-public-index:
 	@./scripts/test-public-index


### PR DESCRIPTION
Adds an arm64 linux build, tested on a Raspberry Pi 4. Includes Actions/CICD support for coverage checking and releasing.