### PR TITLE
installer: fix default pack root initialization

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -77,6 +77,10 @@ func configureInstaller(cmd *cobra.Command, args []string) error {
 				if err != nil {
 					return err
 				}
+				err = installer.SetPackRoot(targetPackRoot, false)
+				if err != nil {
+					return err
+				}
 				installer.LockPackRoot()
 			}
 		} else {


### PR DESCRIPTION
Resets the pack root after performing the internal "init" when using the default pack root, so the
desired command runs with an updated state.

Corrects #128.