### PR TITLE
Added go code vulnerability check scan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,27 @@ jobs:
         run: |
           make format-check
 
+  vulnerability-check:
+    name: "Vulnerability check"
+    strategy:
+      matrix:
+        platform: [ubuntu-latest]
+        go: [1.18.x]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install go 1.18
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - name: Run vulnerability check
+        run: |
+          echo "$(govulncheck ./... 2>&1 | tee vulnerability_report.out)"
+          test -n "$(grep 'No vulnerabilities found.' vulnerability_report.out)"
+
   # Make sure local_repository.pidx is linted against PackIndex.xsd
   xmllint:
     name: Xmllint


### PR DESCRIPTION
Extending github workflow to check go code vulnerabilities using [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck).