### PR TITLE
installer: don't set pack.idx to read only

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -981,6 +981,8 @@ func LockPackRoot() {
 	utils.SetReadOnly(Installation.LocalDir)
 	utils.SetReadOnly(Installation.DownloadDir)
 	utils.SetReadOnly(Installation.PackRoot)
+	// "pack.idx" does not need to be read only
+	utils.UnsetReadOnly(Installation.PackIdx)
 }
 
 // UnlockPackRoot disable the read-only flag for the pack-root directory


### PR DESCRIPTION
Avoids setting `pack.idx` as a read-only file, as other tools should be able to update it.
