### PR TITLE
installer: fix pack name/version regex

### DIFF
--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -23,8 +23,8 @@ import (
 // cpackget pack add Vendor.PackName.x.y.z                         # packID with version
 // cpackget pack add Vendor::PackName                              # packID using legacy syntax
 // cpackget pack add Vendor::PackName@x.y.z                        # packID using legacy syntax specifying an exact version
-// cpackget pack add Vendor::PackName@~x.y.z                       # packID using legacy syntax specifying a minumum compatible version
-// cpackget pack add Vendor::PackName>=x.y.z                       # packID using legacy syntax specifying a minumum version
+// cpackget pack add Vendor::PackName@~x.y.z                       # packID using legacy syntax specifying a minimum compatible version
+// cpackget pack add Vendor::PackName>=x.y.z                       # packID using legacy syntax specifying a minimum version
 // cpackget pack add Vendor.PackName.x.y.z.pack                    # pack file name
 // cpackget pack add https://vendor.com/Vendor.PackName.x.y.z.pack # pack URL
 //
@@ -41,13 +41,12 @@ func TestAddPack(t *testing.T) {
 		installer.UnlockPackRoot()
 		defer removePackRoot(localTestingDir)
 
-		packPath := malformedPackName
-
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, Timeout)
-
-		// Sanity check
-		assert.NotNil(err)
-		assert.Equal(err, errs.ErrBadPackName)
+		for i := 0; i < len(malformedPackNames); i++ {
+			err := installer.AddPack(malformedPackNames[i], !CheckEula, !ExtractEula, !ForceReinstall, Timeout)
+			// Sanity check
+			assert.NotNil(err)
+			assert.Equal(err, errs.ErrBadPackName)
+		}
 
 		// Make sure pack.idx never got touched
 		assert.False(utils.FileExists(installer.Installation.PackIdx))

--- a/cmd/installer/root_pack_list_test.go
+++ b/cmd/installer/root_pack_list_test.go
@@ -266,7 +266,7 @@ func ExampleListInstalledPacks_listMalformedInstalledPacks() {
 	_ = installer.ListInstalledPacks(!ListCached, !ListPublic, ListFilter)
 	// Output:
 	// I: Listing installed packs
-	// E: _TheVendor::_PublicLocalPack@1.2.3.4 - error: vendor, pack name, pack version incorrect format
+	// E: _TheVendor::_PublicLocalPack@1.2.3.4 - error: pack version incorrect format
 	// W: 1 error(s) detected
 }
 
@@ -339,7 +339,7 @@ func ExampleListInstalledPacks_filterErrorPackages() {
 	_ = installer.ListInstalledPacks(!ListCached, !ListPublic, "TheVendor")
 	// Output:
 	// I: Listing installed packs, filtering by "TheVendor"
-	// E: _TheVendor::_PublicLocalPack@1.2.3.4 - error: vendor, pack name, pack version incorrect format
+	// E: _TheVendor::_PublicLocalPack@1.2.3.4 - error: pack version incorrect format
 }
 
 func ExampleListInstalledPacks_filterInvalidChars() {

--- a/cmd/installer/root_pdsc_add_test.go
+++ b/cmd/installer/root_pdsc_add_test.go
@@ -26,8 +26,10 @@ func TestAddPdsc(t *testing.T) {
 		installer.UnlockPackRoot()
 		defer removePackRoot(localTestingDir)
 
-		err := installer.AddPdsc(malformedPackName)
-		assert.Equal(errs.ErrBadPackName, err)
+		for i := 0; i < len(malformedPackNames); i++ {
+			err := installer.AddPdsc(malformedPackNames[i])
+			assert.Equal(errs.ErrBadPackName, err)
+		}
 	})
 
 	t.Run("test add pdsc with bad local_repository.pidx", func(t *testing.T) {

--- a/cmd/installer/root_pdsc_rm_test.go
+++ b/cmd/installer/root_pdsc_rm_test.go
@@ -22,9 +22,11 @@ func TestRemovePdsc(t *testing.T) {
 		installer.UnlockPackRoot()
 		defer removePackRoot(localTestingDir)
 
-		err := installer.RemovePdsc(malformedPackName)
-		assert.NotNil(err)
-		assert.Equal(errs.ErrBadPackName, err)
+		for i := 0; i < len(malformedPackNames); i++ {
+			err := installer.RemovePdsc(malformedPackNames[i])
+			assert.NotNil(err)
+			assert.Equal(errs.ErrBadPackName, err)
+		}
 	})
 
 	t.Run("test remove a pdsc", func(t *testing.T) {

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -228,7 +228,7 @@ var (
 	// Available testing packs
 	testDir = filepath.Join("..", "..", "testdata", "integration")
 
-	malformedPackName              = "pack-with-bad-name"
+	malformedPackNames             = []string{"pAck-WiTH-HiFenS", "[$pecialC#aracter£]", "Spaced Pack Name", " "}
 	packThatDoesNotExist           = "ThisPack.DoesNotExist.0.0.1.pack"
 	packToReinstall                = filepath.Join(testDir, "TheVendor.PackToReinstall.1.2.3.pack")
 	packWithCorruptZip             = filepath.Join(testDir, "FakeZip.PackName.1.2.3.pack")

--- a/cmd/utils/packs.go
+++ b/cmd/utils/packs.go
@@ -14,15 +14,15 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// namePattern specifies a regular expression that matches Vendor and Pack names.
-// Ref: https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/Utilities/PackIndex.xsd
-var namePattern = `[a-zA-Z][0-9a-zA-Z_\-]+`
+// namePattern specifies a regular expression that matches Pack and Vendor names.
+// Ref: https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/4e2ef7dddc4bcd2a43b530d79908720c9c52da9e/schema/PACK.xsd#L1659
+var namePattern = `[\-_A-Za-z0-9]+`
 
 // nameRegex has a pre-compiled namePattern ready for use
 var nameRegex = regexp.MustCompile(fmt.Sprintf("^%s$", namePattern))
 
 // versionPattern validates pack version.
-// Ref: https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/Utilities/PackIndex.xsd
+// Ref: https://github.com/Open-CMSIS-Pack/Open-CMSIS-Pack-Spec/blob/4e2ef7dddc4bcd2a43b530d79908720c9c52da9e/schema/PACK.xsd#L1672
 // With little adjustments to reduce the number of capturing groups to a single one
 //
 //	<major> .<minor> .<patch>   - <quality>                                                                         + <meta info>


### PR DESCRIPTION
Fixes the used regular expression for a pack's name and vendor, which didn't match the current specification. Also adds a more varied selection of incorrect strings to test against.

Closes #143.