### PR TITLE
installer: install latest dependencies if possible

### DIFF
--- a/cmd/utils/packs_test.go
+++ b/cmd/utils/packs_test.go
@@ -340,3 +340,20 @@ func TestExtractPackInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatPackVersion(t *testing.T) {
+	pack := []string{"Pack", "TheVendor", ""}
+
+	// exact
+	pack[2] = "1.0.0:1.0.0"
+	assert.Equal(t, "TheVendor::Pack@1.0.0", utils.FormatPackVersion(pack))
+	// latest
+	pack[2] = "latest"
+	assert.Equal(t, "TheVendor::Pack@latest", utils.FormatPackVersion(pack))
+	// minimum (greater than)
+	pack[2] = "1.0.0:_"
+	assert.Equal(t, "TheVendor::Pack@>=1.0.0", utils.FormatPackVersion(pack))
+	// range
+	pack[2] = "1.0.0:1.2.0"
+	assert.Equal(t, "TheVendor::Pack@1.0.0:1.2.0", utils.FormatPackVersion(pack))
+}


### PR DESCRIPTION
Fixes requirements installation by trying to install the latest version of a pack if none/latest/minimum is specified - following the official spec.

The prompts now use the modern notation (from csolution), adding an unofficional one for version ranges (@1.2.3:1.2.6).

Improves #105.