### PR TITLE
[cpackget] Installing a local pack that does not exist triggers error message twice #151

### DIFF
--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -112,6 +112,8 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 				lastErr = err
 				if !errs.AlreadyLogged(err) {
 					log.Error(err)
+					err = errs.ErrAlreadyLogged
+					lastErr = err
 				}
 			}
 		}

--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -112,8 +112,6 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 				lastErr = err
 				if !errs.AlreadyLogged(err) {
 					log.Error(err)
-					err = errs.ErrAlreadyLogged
-					lastErr = err
 				}
 			}
 		}

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 )
 
+var lastLoggedMessage string
+
 // Is returns true if err is equals to target
 func Is(err, target error) bool {
 	return err == target
@@ -14,6 +16,12 @@ func Is(err, target error) bool {
 
 // AlreadyLogged returns true if the error log has already been logged
 func AlreadyLogged(err error) bool {
+	if err.Error() == lastLoggedMessage {
+		return true
+	}
+
+	lastLoggedMessage = err.Error()
+
 	return err == ErrAlreadyLogged
 }
 


### PR DESCRIPTION
fixed:
- storing last printed error string (if checked via AlreadyLogged() ).  Skipping if already printed.
- Not sure how the "error" type can be enhanced as external libraries are using it.