### PR TITLE
added --skip-touch flag to not touch pack.idx

### DIFF
--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -30,6 +30,9 @@ var addCmdFlags struct {
 
 	// skipEula tells whether pack's license should be presented to the user or not for a yay-or-nay acceptance
 	skipEula bool
+
+	// skipTouch does not touch pack.idx after adding
+	skipTouch bool
 }
 
 var AddCmd = &cobra.Command{
@@ -103,7 +106,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 			if filepath.Ext(packPath) == ".pdsc" {
 				err = installer.AddPdsc(packPath)
 			} else {
-				err = installer.AddPack(packPath, !addCmdFlags.skipEula, addCmdFlags.extractEula, addCmdFlags.forceReinstall, addCmdFlags.noRequirements, viper.GetInt("timeout"))
+				err = installer.AddPack(packPath, !addCmdFlags.skipEula, addCmdFlags.extractEula, addCmdFlags.forceReinstall, addCmdFlags.noRequirements, addCmdFlags.skipTouch, viper.GetInt("timeout"))
 			}
 			if err != nil {
 				lastErr = err
@@ -123,6 +126,7 @@ func init() {
 	AddCmd.Flags().BoolVarP(&addCmdFlags.forceReinstall, "force-reinstall", "F", false, "forces installation of an already installed pack")
 	AddCmd.Flags().BoolVarP(&addCmdFlags.noRequirements, "no-dependencies", "n", false, "do not install package dependencies")
 	AddCmd.Flags().StringVarP(&addCmdFlags.packsListFileName, "packs-list-filename", "f", "", "specifies a file listing packs urls, one per line")
+	AddCmd.Flags().BoolVar(&addCmdFlags.skipTouch, "skip-touch", false, "do not touch pack.idx")
 
 	AddCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
 		// Small workaround to keep the linter happy, not

--- a/cmd/commands/pack.go
+++ b/cmd/commands/pack.go
@@ -83,7 +83,7 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 		var firstError error
 		installer.UnlockPackRoot()
 		for _, packPath := range args {
-			if err := installer.AddPack(packPath, !skipEula, extractEula, forceReinstall, noRequirements, viper.GetInt("timeout")); err != nil {
+			if err := installer.AddPack(packPath, !skipEula, extractEula, forceReinstall, noRequirements, false, viper.GetInt("timeout")); err != nil {
 				if firstError == nil {
 					firstError = err
 				}

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -61,7 +61,7 @@ func GetDefaultCmsisPackRoot() string {
 }
 
 // AddPack adds a pack to the pack installation directory structure
-func AddPack(packPath string, checkEula, extractEula, forceReinstall, noRequirements bool, timeout int) error {
+func AddPack(packPath string, checkEula, extractEula, forceReinstall, noRequirements, skipTouch bool, timeout int) error {
 
 	isDep := false
 	// tag dependency packs with $ for correct logging output
@@ -179,7 +179,7 @@ func AddPack(packPath string, checkEula, extractEula, forceReinstall, noRequirem
 				}
 				if !pack.isInstalled {
 					log.Debug("pack has dependencies, installing")
-					err := AddPack("$"+path, checkEula, extractEula, forceReinstall, false, timeout)
+					err := AddPack("$"+path, checkEula, extractEula, forceReinstall, false, skipTouch, timeout)
 					if err != nil {
 						return err
 					}
@@ -192,6 +192,9 @@ func AddPack(packPath string, checkEula, extractEula, forceReinstall, noRequirem
 		}
 	} else {
 		log.Debug("skipping requirements checking and installation")
+	}
+	if skipTouch {
+		return nil
 	}
 	return Installation.touchPackIdx()
 }

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -42,7 +42,7 @@ func TestAddPack(t *testing.T) {
 		defer removePackRoot(localTestingDir)
 
 		for i := 0; i < len(malformedPackNames); i++ {
-			err := installer.AddPack(malformedPackNames[i], !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+			err := installer.AddPack(malformedPackNames[i], !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 			// Sanity check
 			assert.NotNil(err)
 			assert.Equal(err, errs.ErrBadPackName)
@@ -68,7 +68,7 @@ func TestAddPack(t *testing.T) {
 
 		// Attempt installing it again, this time it should noop
 		packPath = publicLocalPack123
-		assert.Nil(installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout))
+		assert.Nil(installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout))
 
 		// Make sure pack.idx did NOT get touched
 		assert.Equal(packIdxModTime, getPackIdxModTime(t, End))
@@ -81,7 +81,7 @@ func TestAddPack(t *testing.T) {
 		defer removePackRoot(localTestingDir)
 
 		packPath := publicLocalPack123
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		packInfo, err := utils.ExtractPackInfo(packPath)
@@ -98,7 +98,7 @@ func TestAddPack(t *testing.T) {
 		packPath := packToReinstall
 		addPack(t, packPath, ConfigType{})
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		packToReinstall, err := utils.ExtractPackInfo(packPath)
@@ -124,7 +124,7 @@ func TestAddPack(t *testing.T) {
 			utils.ShouldAbortFunction = nil
 		}()
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		// Should not install anything, and revert the temporary pack to its original directory
 		originalPackPath := filepath.Join(installer.Installation.PackRoot, "TheVendor", "PackToReinstall", "1.2.3")
 		assert.True(errs.Is(err, errs.ErrTerminatedByUser))
@@ -140,7 +140,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := packThatDoesNotExist
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -160,7 +160,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := notFoundServer.URL() + packThatDoesNotExist
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -178,7 +178,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := packWithCorruptZip
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -196,7 +196,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := packWithMalformedURL
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -214,7 +214,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := packWithoutPdscFileInside
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -239,7 +239,7 @@ func TestAddPack(t *testing.T) {
 
 			// Force a bad file path
 			installer.Installation.PackRoot = filepath.Join(string(os.PathSeparator), "CON")
-			err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+			err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 			// Sanity check
 			assert.NotNil(err)
@@ -259,7 +259,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := packWithTaintedCompressedFiles
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -277,7 +277,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := pack123MissingVersion
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -295,7 +295,7 @@ func TestAddPack(t *testing.T) {
 
 		packPath := pack123VersionNotLatest
 
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -427,7 +427,7 @@ func TestAddPack(t *testing.T) {
 
 		// Should NOT be installed if license is not agreed
 		ui.LicenseAgreed = &ui.Disagreed
-		err = installer.AddPack(packPath, CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(packPath, CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.Nil(err)
@@ -510,7 +510,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 
 		// Should NOT be installed if license is missing
-		err = installer.AddPack(packPath, CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(packPath, CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 		// Sanity check
 		assert.NotNil(err)
@@ -534,7 +534,7 @@ func TestAddPack(t *testing.T) {
 
 		ui.Extract = true
 		ui.LicenseAgreed = nil
-		err := installer.AddPack(packPath, CheckEula, ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, CheckEula, ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.NotNil(err)
 		assert.Equal(errs.ErrLicenseNotFound, err)
 		assert.False(utils.FileExists(extractedLicensePath))
@@ -559,7 +559,7 @@ func TestAddPack(t *testing.T) {
 		defer removePackRoot(localTestingDir)
 
 		packPath := packWithSubSubFolder
-		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.NotNil(err)
 		assert.Equal(err, errs.ErrPdscFileTooDeepInPack)
 	})
@@ -587,7 +587,7 @@ func TestAddPack(t *testing.T) {
 			err = installer.Installation.PublicIndexXML.AddPdsc(packPdscTag)
 			assert.Nil(err)
 
-			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 			assert.NotNil(err)
 			assert.Equal(err, errs.ErrPackPdscCannotBeFound)
@@ -611,7 +611,7 @@ func TestAddPack(t *testing.T) {
 			// Place the bogus pdsc file in .Web/
 			assert.Nil(utils.CopyFile(pdscPack123MissingVersion, filepath.Join(installer.Installation.WebDir, pack.PdscFileName())))
 
-			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 			assert.NotNil(err)
 			assert.Equal(errs.ErrPackVersionNotFoundInPdsc, err)
@@ -655,7 +655,7 @@ func TestAddPack(t *testing.T) {
 			pdscXML.ReleasesTag.Releases = append(pdscXML.ReleasesTag.Releases, releaseTag)
 			assert.Nil(utils.WriteXML(pdscXML.FileName, pdscXML))
 
-			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 			assert.Nil(err)
 
 			pack.Version = "1.2.3"
@@ -697,7 +697,7 @@ func TestAddPack(t *testing.T) {
 			pdscXML.URL = server.URL()
 			assert.Nil(utils.WriteXML(pdscXML.FileName, pdscXML))
 
-			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 			assert.Nil(err)
 
 			pack.IsPublic = true
@@ -779,7 +779,7 @@ func TestAddPack(t *testing.T) {
 		server.AddRoute(pack123.PackFileName(), pack123Content)
 
 		// Attempt to install with PackID only first time, with no success (no pdsc in .Local)
-		err = installer.AddPack(pack123ID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(pack123ID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Equal(err, errs.ErrPackURLCannotBeFound)
 
 		// Add the pack via file, then remove it just to leave the pdsc in .Local
@@ -789,7 +789,7 @@ func TestAddPack(t *testing.T) {
 
 		// The 1.2.4 pack's PDSC does NOT contain the 1.2.3 release tag on purpose
 		// so an attemp to install it should raise an error
-		err = installer.AddPack(pack123ID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(pack123ID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Equal(err, errs.ErrPackVersionNotFoundInPdsc)
 
 		// Tweak the URL to retrieve version 1.2.3 and inject the 1.2.3 tag
@@ -800,7 +800,7 @@ func TestAddPack(t *testing.T) {
 		pdscXML.URL = server.URL()
 		assert.Nil(utils.WriteXML(pdscXML.FileName, pdscXML))
 
-		err = installer.AddPack(pack123ID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(pack123ID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 		checkPackIsInstalled(t, pack123)
 	})
@@ -830,7 +830,7 @@ func TestAddPack(t *testing.T) {
 		_, packBasePath := filepath.Split(publicRemotePack123)
 
 		packPath := packServer.URL() + packBasePath
-		err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.NotNil(err)
 		assert.Equal(errs.ErrTerminatedByUser, err)
 
@@ -866,7 +866,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 		pack := packInfoToType(packInfo)
 
-		err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.NotNil(err)
 		assert.Equal(errs.ErrTerminatedByUser, err)
 
@@ -912,7 +912,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 		packIdxModTime := packIdx.ModTime()
 
-		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
@@ -956,7 +956,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install >=1.2.3
-		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 1.2.4 is installed
@@ -1004,7 +1004,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install >=1.2.3
-		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 1.2.4 is installed
@@ -1027,7 +1027,7 @@ func TestAddPack(t *testing.T) {
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
 		assert.Nil(utils.CopyFile(pdscPublicLocalPack, packPdscFilePath))
 
-		err := installer.AddPack(publicLocalPack125WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(publicLocalPack125WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Equal(err, errs.ErrPackVersionNotAvailable)
 	})
 
@@ -1072,7 +1072,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install @~0.1.0
-		err = installer.AddPack(publicLocalPack010WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack010WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 0.1.1 is installed
@@ -1114,7 +1114,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install @~0.1.0
-		err = installer.AddPack(publicLocalPack010WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack010WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 0.1.1 is installed
@@ -1162,7 +1162,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install @~0.1.0
-		err = installer.AddPack(publicLocalPack011WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack011WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 0.1.1 is installed
@@ -1194,7 +1194,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 		packIdxModTime := packIdx.ModTime()
 
-		err = installer.AddPack(publicLocalPack011WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack011WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
@@ -1219,7 +1219,7 @@ func TestAddPack(t *testing.T) {
 		packPdscFilePath := filepath.Join(installer.Installation.WebDir, filepath.Base(pdscPublicLocalPack))
 		assert.Nil(utils.CopyFile(pdscPublicLocalPack, packPdscFilePath))
 
-		err := installer.AddPack(publicLocalPack211WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(publicLocalPack211WithMinimumCompatibleVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Equal(err, errs.ErrPackVersionNotAvailable)
 	})
 
@@ -1258,7 +1258,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install @latest
-		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 1.2.4 is installed
@@ -1306,7 +1306,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install @latest
-		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 1.2.4 is installed
@@ -1338,7 +1338,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 		packIdxModTime := packIdx.ModTime()
 
-		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
@@ -1388,7 +1388,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(utils.WriteXML(packPdscFilePath, pdscXML))
 
 		// Install >=1.2.3
-		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPack123WithMinimumVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Check that 1.2.4 is installed
@@ -1414,7 +1414,7 @@ func TestAddPack(t *testing.T) {
 		assert.Nil(err)
 		packIdxModTime := packIdx.ModTime()
 
-		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err = installer.AddPack(publicLocalPackLatestVersionLegacyPackID, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		// Make sure pack.idx did NOT get touched
@@ -1432,7 +1432,7 @@ func TestAddPack(t *testing.T) {
 
 		addPack(t, publicRemotePack123, ConfigType{IsPublic: true})
 
-		err := installer.AddPack(packWithSingleDependency, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packWithSingleDependency, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		packInfo, err := utils.ExtractPackInfo(packWithSingleDependency)
@@ -1449,7 +1449,7 @@ func TestAddPack(t *testing.T) {
 
 		addPack(t, publicRemotePack123alpha, ConfigType{IsPublic: true})
 
-		err := installer.AddPack(packWithSingleDependencyAlpha, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+		err := installer.AddPack(packWithSingleDependencyAlpha, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		packInfo, err := utils.ExtractPackInfo(packWithSingleDependencyAlpha)
@@ -1464,7 +1464,7 @@ func TestAddPack(t *testing.T) {
 		installer.Installation.WebDir = filepath.Join(testDir, "public_index")
 		defer removePackRoot(localTestingDir)
 
-		err := installer.AddPack(packWithSingleDependency, !CheckEula, !ExtractEula, !ForceReinstall, NoRequirements, Timeout)
+		err := installer.AddPack(packWithSingleDependency, !CheckEula, !ExtractEula, !ForceReinstall, NoRequirements, !SkipTouch, Timeout)
 		assert.Nil(err)
 
 		packInfo, err := utils.ExtractPackInfo(packWithSingleDependency)

--- a/cmd/installer/root_pack_list_test.go
+++ b/cmd/installer/root_pack_list_test.go
@@ -96,8 +96,8 @@ func ExampleListInstalledPacks_list() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.5",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
-	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/, Timeout)
 
 	log.SetOutput(os.Stdout)
@@ -133,8 +133,8 @@ func ExampleListInstalledPacks_listCached() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.5",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
-	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/, Timeout)
 
 	log.SetOutput(os.Stdout)
@@ -172,8 +172,8 @@ func TestListInstalledPacks(t *testing.T) {
 			Name:    "PublicLocalPack",
 			Version: "1.2.5",
 		}))
-		assert.Nil(installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout))
-		assert.Nil(installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout))
+		assert.Nil(installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout))
+		assert.Nil(installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout))
 		assert.Nil(installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/, Timeout))
 
 		// Install a pack via PDSC file
@@ -246,7 +246,7 @@ func ExampleListInstalledPacks_listMalformedInstalledPacks() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.3",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 	// Temper with the installation folder
 	currVendorFolder := filepath.Join(localTestingDir, "TheVendor")
@@ -294,8 +294,8 @@ func ExampleListInstalledPacks_filter() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.5",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
-	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/, Timeout)
 
 	log.SetOutput(os.Stdout)
@@ -319,7 +319,7 @@ func ExampleListInstalledPacks_filterErrorPackages() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.3",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 
 	// Temper with the installation folder
 	currVendorFolder := filepath.Join(localTestingDir, "TheVendor")
@@ -366,8 +366,8 @@ func ExampleListInstalledPacks_filterInvalidChars() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.5",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
-	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/, Timeout)
 
 	log.SetOutput(os.Stdout)
@@ -400,8 +400,8 @@ func ExampleListInstalledPacks_filteradditionalMessages() {
 		Name:    "PublicLocalPack",
 		Version: "1.2.5",
 	})
-	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
-	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
+	_ = installer.AddPack(publicLocalPack123, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
+	_ = installer.AddPack(publicLocalPack124, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, !SkipTouch, Timeout)
 	_ = installer.RemovePack("TheVendor.PublicLocalPack.1.2.3", false /*no purge*/, Timeout)
 
 	log.SetOutput(os.Stdout)

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -128,6 +128,7 @@ type ConfigType struct {
 	ForceReinstall bool
 	IsPublic       bool
 	NoRequirements bool
+	SkipTouch	   bool
 }
 
 func addPack(t *testing.T, packPath string, config ConfigType) {
@@ -136,7 +137,7 @@ func addPack(t *testing.T, packPath string, config ConfigType) {
 	// Get pack.idx before removing pack
 	packIdxModTime := getPackIdxModTime(t, Start)
 
-	err := installer.AddPack(packPath, config.CheckEula, config.ExtractEula, config.ForceReinstall, config.NoRequirements, Timeout)
+	err := installer.AddPack(packPath, config.CheckEula, config.ExtractEula, config.ForceReinstall, config.NoRequirements, config.SkipTouch, Timeout)
 	assert.Nil(err)
 
 	if config.ExtractEula {
@@ -223,6 +224,7 @@ var (
 	IsPublic       = true
 	NotPublic      = false
 	NoRequirements = true
+	SkipTouch      = true
 	Timeout        = 0
 
 	CreatePackRoot = true


### PR DESCRIPTION
Using --skip-touch with add command will skip touching pack.idx file.