### PR TITLE
[cpackget] MacOS tests failing #150

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,14 +98,14 @@ jobs:
     strategy:
       matrix:
         # Tests on Mac are currently broken
-        goos: [windows, linux] # , darwin]
+        goos: [windows, linux, darwin]
         include:
           - goos: windows
             runs-on: windows-latest
           - goos: linux
             runs-on: ubuntu-latest
-#          - goos: darwin
-#            runs-on: macos-latest
+          - goos: darwin
+            runs-on: macos-latest
 
     name: "${{ matrix.goos }} | amd64"
     runs-on: ${{ matrix.runs-on }}

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -219,6 +219,8 @@ func MoveFile(source, destination string) error {
 		return errs.ErrCopyingEqualPaths
 	}
 
+	UnsetReadOnly(source)
+
 	err := os.Rename(source, destination)
 	if err != nil {
 		log.Errorf("Can't move file \"%s\" to \"%s\": %s", source, destination, err)


### PR DESCRIPTION
fixed:
- clearing RO flag before renaming of files / folders. Required on MAC to run on RO-directories