### PR TITLE
[cpackget] Debug log level not working on some commands #131

### DIFF
--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -55,7 +55,8 @@ The default Cryptographic Hash Function used is "` + cryptography.Hashes[0] + `"
 might be supported. The used function will be prefixed to the ".checksum" extension.
 
 By default the checksum file will be created in the same directory as the provided pack.`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
 	},
@@ -73,7 +74,8 @@ with "checksum-create"), present in the same directory:
 The used hash function is inferred from the checksum filename, and if any of the digests
 computed doesn't match the one provided in the checksum file an error will be thrown.
 If the .checksum file is in another directory, specify it with the -p/--path flag`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if checksumVerifyCmdFlags.checksumPath != "" {
 			return cryptography.VerifyChecksum(args[0], checksumVerifyCmdFlags.checksumPath)

--- a/cmd/commands/signature.go
+++ b/cmd/commands/signature.go
@@ -96,7 +96,8 @@ These can be viewed with any text/hex editor or dedicated zip tools like "zipinf
 The referenced pack must be in its original/compressed form (.pack), and be present locally:
 
   $ cpackget signature-create Vendor.Pack.1.2.3.pack -k private.key -c certificate.pem`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureCreateflags.keyPath == "" {
 			if !signatureCreateflags.certOnly {
@@ -152,7 +153,8 @@ the publisher's public PGP key.
 The referenced pack must be in its original/compressed form (.pack), and be present locally:
 
   $ cpackget signature-verify Vendor.Pack.1.2.3.pack.signed`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureVerifyflags.export && (signatureVerifyflags.skipCertValidation || signatureVerifyflags.skipInfo) {
 			log.Error("-e/--export does not need any other flags")


### PR DESCRIPTION
fixed:
- Init was missing in COBRA structs: PersistentPreRunE: configureInstaller
- function crashes on empty string: sanitizeVersionForSignature()