### PR TITLE
[cpackget] Debug log level not working on some commands #131

### DIFF
--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -56,7 +56,7 @@ might be supported. The used function will be prefixed to the ".checksum" extens
 
 By default the checksum file will be created in the same directory as the provided pack.`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstaller,
+	PersistentPreRunE: configureInstallerVerbose,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
 	},
@@ -75,7 +75,7 @@ The used hash function is inferred from the checksum filename, and if any of the
 computed doesn't match the one provided in the checksum file an error will be thrown.
 If the .checksum file is in another directory, specify it with the -p/--path flag`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstaller,
+	PersistentPreRunE: configureInstallerVerbose,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if checksumVerifyCmdFlags.checksumPath != "" {
 			return cryptography.VerifyChecksum(args[0], checksumVerifyCmdFlags.checksumPath)

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -55,7 +55,8 @@ The default Cryptographic Hash Function used is "` + cryptography.Hashes[0] + `"
 might be supported. The used function will be prefixed to the ".checksum" extension.
 
 By default the checksum file will be created in the same directory as the provided pack.`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
 	},
@@ -73,7 +74,8 @@ with "checksum-create"), present in the same directory:
 The used hash function is inferred from the checksum filename, and if any of the digests
 computed doesn't match the one provided in the checksum file an error will be thrown.
 If the .checksum file is in another directory, specify it with the -p/--path flag`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if checksumVerifyCmdFlags.checksumPath != "" {
 			return cryptography.VerifyChecksum(args[0], checksumVerifyCmdFlags.checksumPath)

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -42,8 +42,7 @@ const defaultPublicIndex = "https://www.keil.com/pack/index.pidx"
 
 var viper *viperType.Viper
 
-// configureInstaller configures cpackget installer for adding or removing pack/pdsc
-func configureInstaller(cmd *cobra.Command, args []string) error {
+func configureInstallerVerbose(cmd *cobra.Command, args []string) error {
 	verbosiness := viper.GetBool("verbose")
 	quiet := viper.GetBool("quiet")
 	if quiet && verbosiness {
@@ -59,6 +58,16 @@ func configureInstaller(cmd *cobra.Command, args []string) error {
 
 	if verbosiness {
 		log.SetLevel(log.DebugLevel)
+	}
+
+	return nil
+}
+
+// configureInstaller configures cpackget installer for adding or removing pack/pdsc
+func configureInstaller(cmd *cobra.Command, args []string) error {
+	err := configureInstallerVerbose(cmd, args)
+	if err != nil {
+		return err
 	}
 
 	targetPackRoot := viper.GetString("pack-root")

--- a/cmd/commands/signature.go
+++ b/cmd/commands/signature.go
@@ -96,7 +96,8 @@ These can be viewed with any text/hex editor or dedicated zip tools like "zipinf
 The referenced pack must be in its original/compressed form (.pack), and be present locally:
 
   $ cpackget signature-create Vendor.Pack.1.2.3.pack -k private.key -c certificate.pem`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureCreateflags.keyPath == "" {
 			if !signatureCreateflags.certOnly {
@@ -152,7 +153,8 @@ the publisher's public PGP key.
 The referenced pack must be in its original/compressed form (.pack), and be present locally:
 
   $ cpackget signature-verify Vendor.Pack.1.2.3.pack.signed`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureVerifyflags.export && (signatureVerifyflags.skipCertValidation || signatureVerifyflags.skipInfo) {
 			log.Error("-e/--export does not need any other flags")

--- a/cmd/commands/signature.go
+++ b/cmd/commands/signature.go
@@ -97,7 +97,7 @@ The referenced pack must be in its original/compressed form (.pack), and be pres
 
   $ cpackget signature-create Vendor.Pack.1.2.3.pack -k private.key -c certificate.pem`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstaller,
+	PersistentPreRunE: configureInstallerVerbose,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureCreateflags.keyPath == "" {
 			if !signatureCreateflags.certOnly {
@@ -154,7 +154,7 @@ The referenced pack must be in its original/compressed form (.pack), and be pres
 
   $ cpackget signature-verify Vendor.Pack.1.2.3.pack.signed`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstaller,
+	PersistentPreRunE: configureInstallerVerbose,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureVerifyflags.export && (signatureVerifyflags.skipCertValidation || signatureVerifyflags.skipInfo) {
 			log.Error("-e/--export does not need any other flags")

--- a/cmd/cryptography/utils.go
+++ b/cmd/cryptography/utils.go
@@ -200,7 +200,7 @@ func isPrivateKeyFromCertificate(cert *x509.Certificate, keyDER []byte, keyType 
 // from source vs an automated release.
 func sanitizeVersionForSignature(version string) string {
 	v := sigVersionPrefix
-	if string(version[0]) != "v" {
+	if version != "" && string(version[0]) != "v" {
 		return v + "v" + version
 	}
 	return v + version

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// foo comment
 func main() {
 	log.SetFormatter(new(LogFormatter))
 	log.SetOutput(os.Stdout)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,7 +12,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// foo comment
 func main() {
 	log.SetFormatter(new(LogFormatter))
 	log.SetOutput(os.Stdout)


### PR DESCRIPTION
Branch should be named cpackget#131_2

fixed:
- initializing verbose option
- fixed crash in sanitizeVersionForSignature() accessing [0] of empty string
