### PR TITLE
Use keil.com/pack/ as default address to fetch PDSC files

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const keilDefaultPackRoot string = "https://www.keil.com/pack/"
+const keilDefaultPackRoot = "https://www.keil.com/pack/"
 
 // GetDefaultCmsisPackRoot provides a default location
 // for the pack root if not provided. This is to enable
@@ -1052,6 +1052,8 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, wg *sync.W
 	}
 
 	var pdscURL string = pdscTag.URL
+
+	Installation.
 
 	// switch  to keil.com cache for PDSC file
 	if pdscURL != keilDefaultPackRoot {

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -1051,7 +1051,7 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, wg *sync.W
 		defer wg.Done()
 	}
 
-	var pdscURL string = pdscTag.URL
+	pdscURL := pdscTag.URL
 
 	// switch  to keil.com cache for PDSC file
 	if pdscURL != keilDefaultPackRoot {

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const keilDefaultPackRoot = "https://www.keil.com/pack/"
+const KeilDefaultPackRoot = "https://www.keil.com/pack/"
 
 // GetDefaultCmsisPackRoot provides a default location
 // for the pack root if not provided. This is to enable
@@ -1054,10 +1054,10 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, wg *sync.W
 	pdscURL := pdscTag.URL
 
 	// switch  to keil.com cache for PDSC file
-	if pdscURL != keilDefaultPackRoot {
-		if Installation.PublicIndexXML.URL == keilDefaultPackRoot {
-			log.Debugf("Switching to cache: \"%s\"", keilDefaultPackRoot)
-			pdscURL = keilDefaultPackRoot
+	if pdscURL != KeilDefaultPackRoot {
+		if Installation.PublicIndexXML.URL == KeilDefaultPackRoot {
+			log.Debugf("Switching to cache: \"%s\"", KeilDefaultPackRoot)
+			pdscURL = KeilDefaultPackRoot
 		}
 	}
 

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const keilDefaultPackRoot string = "https://www.keil.com/pack/"
+const keilDefaultPackRoot = "https://www.keil.com/pack/"
 
 // GetDefaultCmsisPackRoot provides a default location
 // for the pack root if not provided. This is to enable
@@ -1052,8 +1052,6 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, wg *sync.W
 	}
 
 	var pdscURL string = pdscTag.URL
-
-	Installation.
 
 	// switch  to keil.com cache for PDSC file
 	if pdscURL != keilDefaultPackRoot {

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -1054,11 +1054,9 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, wg *sync.W
 	pdscURL := pdscTag.URL
 
 	// switch  to keil.com cache for PDSC file
-	if pdscURL != KeilDefaultPackRoot {
-		if Installation.PublicIndexXML.URL == KeilDefaultPackRoot {
-			log.Debugf("Switching to cache: \"%s\"", KeilDefaultPackRoot)
-			pdscURL = KeilDefaultPackRoot
-		}
+	if pdscURL != KeilDefaultPackRoot && Installation.PublicIndexXML.URL == KeilDefaultPackRoot {
+		log.Debugf("Switching to cache: \"%s\"", KeilDefaultPackRoot)
+		pdscURL = KeilDefaultPackRoot
 	}
 
 	basePdscFile := fmt.Sprintf("%s.%s.pdsc", pdscTag.Vendor, pdscTag.Name)

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -22,7 +22,7 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-const keilDefaultPackRoot = "https://www.keil.com/pack/"
+const keilDefaultPackRoot string = "https://www.keil.com/pack/"
 
 // GetDefaultCmsisPackRoot provides a default location
 // for the pack root if not provided. This is to enable

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -22,6 +22,8 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+const keilDefaultPackRoot string = "https://www.keil.com/pack/"
+
 // GetDefaultCmsisPackRoot provides a default location
 // for the pack root if not provided. This is to enable
 // a "default mode", where the public index will be
@@ -1049,14 +1051,24 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, wg *sync.W
 		defer wg.Done()
 	}
 
+	var pdscURL string = pdscTag.URL
+
+	// switch  to keil.com cache for PDSC file
+	if pdscURL != keilDefaultPackRoot {
+		if Installation.PublicIndexXML.URL == keilDefaultPackRoot {
+			log.Debugf("Switching to cache: \"%s\"", keilDefaultPackRoot)
+			pdscURL = keilDefaultPackRoot
+		}
+	}
+
 	basePdscFile := fmt.Sprintf("%s.%s.pdsc", pdscTag.Vendor, pdscTag.Name)
 	pdscFilePath := filepath.Join(p.WebDir, basePdscFile)
 
-	log.Debugf("Downloading %s from \"%s\"", basePdscFile, pdscTag.URL)
+	log.Debugf("Downloading %s from \"%s\"", basePdscFile, pdscURL)
 
-	pdscFileURL, err := url.Parse(pdscTag.URL)
+	pdscFileURL, err := url.Parse(pdscURL)
 	if err != nil {
-		log.Errorf("Could not parse pdsc url \"%s\": %s", pdscTag.URL, err)
+		log.Errorf("Could not parse pdsc url \"%s\": %s", pdscURL, err)
 		return errs.ErrAlreadyLogged
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/open-cmsis-pack/cpackget/cmd/commands"
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
@@ -17,6 +18,7 @@ func main() {
 	log.SetOutput(os.Stdout)
 
 	utils.StartSignalWatcher()
+	start := time.Now()
 
 	commands.Version = version
 	commands.CopyRight = copyRight
@@ -29,5 +31,6 @@ func main() {
 		os.Exit(-1)
 	}
 
+	log.Debugf("Took %v", time.Since(start))
 	utils.StopSignalWatcher()
 }


### PR DESCRIPTION
Switching to "https://www.keil.com/pack/" if index.pidx was downloaded from there, to fetch PDSC files. 
Assumption: fetching from this location is faster and more reliable (PDSCs are verified), and PDSC files are always cached there (lags prob. up to 1 day).

Test (today): Fetching "as is" takes around 1:50 min, redirecting all PDSCs to keil.com takes around 2:30 min.
`"args": ["init", "https://www.keil.com/pack/index.pidx", "-a", "-v",]`

See https://github.com/Open-CMSIS-Pack/cpackget/issues/182