### PR TITLE
[cpackget] If PDSC file is no longer listed in index.pidx, it shall be removed from .Web folder

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -405,7 +405,9 @@ func UpdatePublicIndex(indexPath string, overwrite bool, sparse bool, downloadPd
 			// Warn the user if the pack is no longer present in index.pidx
 			tags := pidxXML.FindPdscTags(searchTag)
 			if len(tags) == 0 {
-				log.Warnf("The pack %s::%s is no longer present in the updated index.pidx", pdscXML.Vendor, pdscXML.Name)
+				log.Warnf("The pack %s::%s is no longer present in the updated index.pidx, deleting PDSC file \"%v\"", pdscXML.Vendor, pdscXML.Name, pdscFile)
+				utils.UnsetReadOnly(pdscFile)
+				os.Remove(pdscFile)
 				continue
 			}
 

--- a/testdata/integration/TheVendor.PackNotInIndex.pdsc
+++ b/testdata/integration/TheVendor.PackNotInIndex.pdsc
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="PACK.xsd">
+   <vendor>TheVendor</vendor>
+   <url>http://vendor.com/packs/</url>
+   <name>PackNotInIndex</name>
+   <description>Sample pack just for testing</description>
+   <releases>
+      <release version="1.0.0">Initial release.</release>
+   </releases>
+</package>


### PR DESCRIPTION
Added to current implementation (warning only), Message extended to:
W: The pack FOO::FOO_DFP is no longer present in the updated index.pidx, deleting PDSC file "C:\Users\thode01\AppData\Local\Arm\Packs\.Web\foo.bar.pdsc"