### PR TITLE
[cpackget] Encoded progress, when tool is called from other tools

### DIFF
--- a/cmd/commands/add.go
+++ b/cmd/commands/add.go
@@ -11,6 +11,7 @@ import (
 
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+	"github.com/open-cmsis-pack/cpackget/cmd/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,9 @@ var addCmdFlags struct {
 
 	// skipTouch does not touch pack.idx after adding
 	skipTouch bool
+
+	// Reports encoded progress for files and download when used by other tools
+	encodedProgress bool
 }
 
 var AddCmd = &cobra.Command{
@@ -64,6 +68,8 @@ If "-f" is used, cpackget will call "cpackget pack add" on each URL specified in
 	Args:              cobra.MinimumNArgs(0),
 	PersistentPreRunE: configureInstaller,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		utils.SetEncodedProgress(addCmdFlags.encodedProgress)
 
 		if addCmdFlags.packsListFileName != "" {
 			log.Infof("Parsing packs urls via file %v", addCmdFlags.packsListFileName)
@@ -127,6 +133,7 @@ func init() {
 	AddCmd.Flags().BoolVarP(&addCmdFlags.noRequirements, "no-dependencies", "n", false, "do not install package dependencies")
 	AddCmd.Flags().StringVarP(&addCmdFlags.packsListFileName, "packs-list-filename", "f", "", "specifies a file listing packs urls, one per line")
 	AddCmd.Flags().BoolVar(&addCmdFlags.skipTouch, "skip-touch", false, "do not touch pack.idx")
+	AddCmd.Flags().BoolVarP(&addCmdFlags.encodedProgress, "encoded-progress", "E", false, "Reports encoded progress for files and download when used by other tools")
 
 	AddCmd.SetHelpFunc(func(command *cobra.Command, strings []string) {
 		// Small workaround to keep the linter happy, not

--- a/cmd/commands/checksum.go
+++ b/cmd/commands/checksum.go
@@ -56,7 +56,7 @@ might be supported. The used function will be prefixed to the ".checksum" extens
 
 By default the checksum file will be created in the same directory as the provided pack.`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstallerVerbose,
+	PersistentPreRunE: configureInstallerGlobalCmd,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return cryptography.GenerateChecksum(args[0], checksumCreateCmdFlags.outputDir, checksumCreateCmdFlags.hashAlgorithm)
 	},
@@ -75,7 +75,7 @@ The used hash function is inferred from the checksum filename, and if any of the
 computed doesn't match the one provided in the checksum file an error will be thrown.
 If the .checksum file is in another directory, specify it with the -p/--path flag`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstallerVerbose,
+	PersistentPreRunE: configureInstallerGlobalCmd,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if checksumVerifyCmdFlags.checksumPath != "" {
 			return cryptography.VerifyChecksum(args[0], checksumVerifyCmdFlags.checksumPath)

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -13,9 +13,7 @@ import (
 var initCmdFlags struct {
 	// downloadPdscFiles forces all pdsc files from the public index to be downloaded
 	downloadPdscFiles bool
-
-	// Reports encoded progress for files and download when used by other tools
-	encodedProgress bool
+	encodedProgress   bool
 }
 
 var InitCmd = &cobra.Command{

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -13,7 +13,9 @@ import (
 var initCmdFlags struct {
 	// downloadPdscFiles forces all pdsc files from the public index to be downloaded
 	downloadPdscFiles bool
-	encodedProgress   bool
+
+	// Reports encoded progress for files and download when used by other tools
+	encodedProgress bool
 }
 
 var InitCmd = &cobra.Command{

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+	"github.com/open-cmsis-pack/cpackget/cmd/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -12,6 +13,7 @@ import (
 var initCmdFlags struct {
 	// downloadPdscFiles forces all pdsc files from the public index to be downloaded
 	downloadPdscFiles bool
+	encodedProgress   bool
 }
 
 var InitCmd = &cobra.Command{
@@ -27,6 +29,8 @@ The index-url is mandatory. Ex "cpackget init --pack-root path/to/mypackroot htt
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		packRoot := viper.GetString("pack-root")
+		utils.SetEncodedProgress(initCmdFlags.encodedProgress)
+
 		indexPath := args[0]
 
 		log.Debugf("Initializing a new pack root in \"%v\" using index url \"%v\"", packRoot, indexPath)
@@ -46,4 +50,5 @@ The index-url is mandatory. Ex "cpackget init --pack-root path/to/mypackroot htt
 
 func init() {
 	InitCmd.Flags().BoolVarP(&initCmdFlags.downloadPdscFiles, "all-pdsc-files", "a", false, "downloads all the latest .pdsc files from the public index")
+	InitCmd.Flags().BoolVarP(&initCmdFlags.encodedProgress, "encoded-progress", "E", false, "Reports encoded progress for files and download when used by other tools")
 }

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -60,9 +60,6 @@ func configureInstallerGlobalCmd(cmd *cobra.Command, args []string) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	encodedProgress := viper.GetBool("encoded-progress")
-	utils.SetEncodedProgress(encodedProgress)
-
 	return nil
 }
 
@@ -176,7 +173,6 @@ func NewCli() *cobra.Command {
 	rootCmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Prints the version number of cpackget and exit")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run cpackget silently, printing only error messages")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
-	rootCmd.PersistentFlags().BoolP("encoded-progress", "E", false, "Reports encoded progress for files and download when used by other tools")
 	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable")
 	rootCmd.PersistentFlags().UintP("concurrent-downloads", "C", 5, "Number of concurrent batch downloads. Set to 0 to disable concurrency")
 	rootCmd.PersistentFlags().UintP("timeout", "T", 0, "Set maximum duration (in seconds) of a download. Disabled by default")
@@ -185,7 +181,6 @@ func NewCli() *cobra.Command {
 	_ = viper.BindPFlag("pack-root", rootCmd.PersistentFlags().Lookup("pack-root"))
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	_ = viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
-	_ = viper.BindPFlag("encoded-progress", rootCmd.PersistentFlags().Lookup("encoded-progress"))
 
 	for _, cmd := range AllCommands {
 		rootCmd.AddCommand(cmd)

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -42,7 +42,7 @@ const defaultPublicIndex = "https://www.keil.com/pack/index.pidx"
 
 var viper *viperType.Viper
 
-func configureInstallerVerbose(cmd *cobra.Command, args []string) error {
+func configureInstallerGlobalCmd(cmd *cobra.Command, args []string) error {
 	verbosiness := viper.GetBool("verbose")
 	quiet := viper.GetBool("quiet")
 	if quiet && verbosiness {
@@ -60,12 +60,15 @@ func configureInstallerVerbose(cmd *cobra.Command, args []string) error {
 		log.SetLevel(log.DebugLevel)
 	}
 
+	encodedProgress := viper.GetBool("encoded-progress")
+	utils.SetEncodedProgress(encodedProgress)
+
 	return nil
 }
 
 // configureInstaller configures cpackget installer for adding or removing pack/pdsc
 func configureInstaller(cmd *cobra.Command, args []string) error {
-	err := configureInstallerVerbose(cmd, args)
+	err := configureInstallerGlobalCmd(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -173,6 +176,7 @@ func NewCli() *cobra.Command {
 	rootCmd.Flags().BoolVarP(&flags.version, "version", "V", false, "Prints the version number of cpackget and exit")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run cpackget silently, printing only error messages")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
+	rootCmd.PersistentFlags().BoolP("encoded-progress", "E", false, "Reports encoded progress for files and download when used by other tools")
 	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable")
 	rootCmd.PersistentFlags().UintP("concurrent-downloads", "C", 5, "Number of concurrent batch downloads. Set to 0 to disable concurrency")
 	rootCmd.PersistentFlags().UintP("timeout", "T", 0, "Set maximum duration (in seconds) of a download. Disabled by default")
@@ -181,6 +185,7 @@ func NewCli() *cobra.Command {
 	_ = viper.BindPFlag("pack-root", rootCmd.PersistentFlags().Lookup("pack-root"))
 	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	_ = viper.BindPFlag("quiet", rootCmd.PersistentFlags().Lookup("quiet"))
+	_ = viper.BindPFlag("encoded-progress", rootCmd.PersistentFlags().Lookup("encoded-progress"))
 
 	for _, cmd := range AllCommands {
 		rootCmd.AddCommand(cmd)

--- a/cmd/commands/signature.go
+++ b/cmd/commands/signature.go
@@ -97,7 +97,7 @@ The referenced pack must be in its original/compressed form (.pack), and be pres
 
   $ cpackget signature-create Vendor.Pack.1.2.3.pack -k private.key -c certificate.pem`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstallerVerbose,
+	PersistentPreRunE: configureInstallerGlobalCmd,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureCreateflags.keyPath == "" {
 			if !signatureCreateflags.certOnly {
@@ -154,7 +154,7 @@ The referenced pack must be in its original/compressed form (.pack), and be pres
 
   $ cpackget signature-verify Vendor.Pack.1.2.3.pack.signed`,
 	Args:              cobra.ExactArgs(1),
-	PersistentPreRunE: configureInstallerVerbose,
+	PersistentPreRunE: configureInstallerGlobalCmd,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if signatureVerifyflags.export && (signatureVerifyflags.skipCertValidation || signatureVerifyflags.skipInfo) {
 			log.Error("-e/--export does not need any other flags")

--- a/cmd/commands/update_index.go
+++ b/cmd/commands/update_index.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/open-cmsis-pack/cpackget/cmd/installer"
+	"github.com/open-cmsis-pack/cpackget/cmd/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -17,6 +18,9 @@ var updateIndexCmdFlags struct {
 	sparse bool
 	// downloadPdscFiles forces all pdsc files from the public index to be downloaded
 	downloadUpdatePdscFiles bool
+
+	// Reports encoded progress for files and download when used by other tools
+	encodedProgress bool
 }
 
 var UpdateIndexCmd = &cobra.Command{
@@ -26,6 +30,7 @@ var UpdateIndexCmd = &cobra.Command{
 	PersistentPreRunE: configureInstaller,
 	Args:              cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		utils.SetEncodedProgress(updateIndexCmdFlags.encodedProgress)
 		log.Infof("Updating public index")
 		installer.UnlockPackRoot()
 		err := installer.UpdatePublicIndex("", true, updateIndexCmdFlags.sparse, false, updateIndexCmdFlags.downloadUpdatePdscFiles, viper.GetInt("concurrent-downloads"), viper.GetInt("timeout"))
@@ -49,4 +54,5 @@ By default it will also check if all PDSC files under .Web/ need update as well.
 func init() {
 	UpdateIndexCmd.Flags().BoolVarP(&updateIndexCmdFlags.sparse, "sparse", "s", false, "avoid updating the pdsc files within .Web/ folder")
 	UpdateIndexCmd.Flags().BoolVarP(&updateIndexCmdFlags.downloadUpdatePdscFiles, "all-pdsc-files", "a", false, "updates/downloads all the latest .pdsc files from the public index")
+	UpdateIndexCmd.Flags().BoolVarP(&updateIndexCmdFlags.encodedProgress, "encoded-progress", "E", false, "Reports encoded progress for files and download when used by other tools")
 }

--- a/cmd/utils/encodedProgress.go
+++ b/cmd/utils/encodedProgress.go
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package utils
+
+import (
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type EncodedProgress struct {
+	mu             sync.Mutex
+	total          int64
+	current        int
+	currentPercent int
+	instanceNo     int
+	name           string
+}
+
+func NewEncodedProgress(max int64, instNo int, filename string) *EncodedProgress {
+	return &EncodedProgress{
+		total:      max,
+		instanceNo: instNo,
+		name:       filename,
+	}
+}
+
+func (p *EncodedProgress) Add(count int) int {
+	p.mu.Lock()
+	newCount := count
+	p.current += newCount
+	p.Print()
+	p.mu.Unlock()
+	return newCount
+}
+
+func (p *EncodedProgress) Write(bs []byte) (int, error) {
+	p.mu.Lock()
+	newCount := len(bs)
+	p.current += newCount
+	p.Print()
+	p.mu.Unlock()
+	return newCount, nil
+}
+
+/* Encodes information to show progress when called by GUI or other tools
+ * I: Instance number (always counts up), connected to the filename
+ * F: Filename currently processed
+ * T: Total bytes of file or numbers of files
+ * P: Currently processed percentage
+ * C: Currently processed bytes or numbers of files
+ */
+func (p *EncodedProgress) Print() {
+	newPercent := int(float64(p.current) / float64(p.total) * 100)
+	if p.currentPercent != newPercent {
+		if p.currentPercent == 0 {
+			log.Infof("[I%d:F%s,T%d,P%d]", p.instanceNo, p.name, p.total, newPercent)
+		} else {
+			log.Infof("[I%d:P%d,C%d]", p.instanceNo, newPercent, p.current)
+		}
+		p.currentPercent = newPercent
+	}
+}

--- a/cmd/utils/encodedProgress.go
+++ b/cmd/utils/encodedProgress.go
@@ -50,7 +50,7 @@ func (p *EncodedProgress) Print() {
 	newPercent := int(float64(p.current) / float64(p.total) * 100)
 	if p.currentPercent != newPercent {
 		if p.currentPercent == 0 {
-			log.Infof("[I%d:F%s,T%d,P%d]", p.instanceNo, p.name, p.total, newPercent)
+			log.Infof("[I%d:F\"%s\",T%d,P%d]", p.instanceNo, p.name, p.total, newPercent)
 		} else {
 			log.Infof("[I%d:P%d,C%d]", p.instanceNo, newPercent, p.current)
 		}

--- a/cmd/utils/encodedProgress.go
+++ b/cmd/utils/encodedProgress.go
@@ -36,11 +36,8 @@ func (p *EncodedProgress) Add(count int) int {
 }
 
 func (p *EncodedProgress) Write(bs []byte) (int, error) {
-	p.mu.Lock()
 	newCount := len(bs)
-	p.current += newCount
-	p.Print()
-	p.mu.Unlock()
+	p.Add(newCount)
 	return newCount, nil
 }
 

--- a/cmd/utils/encodedProgress.go
+++ b/cmd/utils/encodedProgress.go
@@ -36,9 +36,7 @@ func (p *EncodedProgress) Add(count int) int {
 }
 
 func (p *EncodedProgress) Write(bs []byte) (int, error) {
-	newCount := len(bs)
-	p.Add(newCount)
-	return newCount, nil
+	return p.Add(len(bs)), nil
 }
 
 /* Encodes information to show progress when called by GUI or other tools

--- a/cmd/utils/encodedProgress_test.go
+++ b/cmd/utils/encodedProgress_test.go
@@ -71,7 +71,7 @@ func TestEncodedProgres(t *testing.T) {
 			progressWriter.Add(1)
 		}
 
-		assert.True(gText == "I: [I0:FTesting,T10,P10]\nI: [I0:P20,C2]\nI: [I0:P30,C3]\nI: [I0:P40,C4]\nI: [I0:P50,C5]\nI: [I0:P60,C6]\nI: [I0:P70,C7]\nI: [I0:P80,C8]\nI: [I0:P90,C9]\nI: [I0:P100,C10]\n")
+		assert.True(gText == "I: [I0:F\"Testing\",T10,P10]\nI: [I0:P20,C2]\nI: [I0:P30,C3]\nI: [I0:P40,C4]\nI: [I0:P50,C5]\nI: [I0:P60,C6]\nI: [I0:P70,C7]\nI: [I0:P80,C8]\nI: [I0:P90,C9]\nI: [I0:P100,C10]\n")
 	})
 
 	t.Run("test encoded progress with write interface", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestEncodedProgres(t *testing.T) {
 
 		fmt.Fprint(progressWriter, text)
 
-		assert.True(gText == "I: [I0:FTesting,T31,P100]\n")
+		assert.True(gText == "I: [I0:F\"Testing\",T31,P100]\n")
 	})
 
 }

--- a/cmd/utils/encodedProgress_test.go
+++ b/cmd/utils/encodedProgress_test.go
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright Contributors to the cpackget project. */
+
+package utils_test
+
+import (
+	"io"
+	"testing"
+
+	"github.com/open-cmsis-pack/cpackget/cmd/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+var gText string
+
+// LogCapturer reroutes testing.T log output
+type LogCapturer interface {
+	Release()
+}
+
+type logCapturer struct {
+	*testing.T
+	origOut io.Writer
+}
+
+func (tl logCapturer) Write(p []byte) (n int, err error) {
+	//tl.Logf((string)(p))
+	gText += string(p)
+	return len(p), nil
+}
+
+func (tl logCapturer) Release() {
+	logrus.SetOutput(tl.origOut)
+}
+
+// CaptureLog redirects logrus output to testing.Log
+func CaptureLog(t *testing.T) LogCapturer {
+	lc := logCapturer{T: t, origOut: logrus.StandardLogger().Out}
+	if !testing.Verbose() {
+		logrus.SetOutput(lc)
+	}
+	gText = ""
+	return &lc
+}
+
+func Add() {
+	maxCnt := int64(10)
+	progressWriter := utils.NewEncodedProgress(maxCnt, 0, "Test progressbar")
+
+	for i := int64(0); i < maxCnt; i++ {
+		progressWriter.Add(1)
+	}
+
+}
+
+func TestEncodedProgres(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("test encoded progress", func(t *testing.T) {
+		Log := CaptureLog(t)
+		defer Log.Release()
+
+		length := int64(10)
+		instCnt := 0
+		fileBase := "Testing"
+		progressWriter := utils.NewEncodedProgress(length, instCnt, fileBase)
+
+		for i := int64(0); i < length; i++ {
+			progressWriter.Add(1)
+		}
+
+		assert.True(gText == "I: [I0:FTesting,T10,P10]\nI: [I0:P20,C2]\nI: [I0:P30,C3]\nI: [I0:P40,C4]\nI: [I0:P50,C5]\nI: [I0:P60,C6]\nI: [I0:P70,C7]\nI: [I0:P80,C8]\nI: [I0:P90,C9]\nI: [I0:P100,C10]\n")
+	})
+}

--- a/cmd/utils/encodedProgress_test.go
+++ b/cmd/utils/encodedProgress_test.go
@@ -4,6 +4,7 @@
 package utils_test
 
 import (
+	"fmt"
 	"io"
 	"testing"
 
@@ -72,4 +73,20 @@ func TestEncodedProgres(t *testing.T) {
 
 		assert.True(gText == "I: [I0:FTesting,T10,P10]\nI: [I0:P20,C2]\nI: [I0:P30,C3]\nI: [I0:P40,C4]\nI: [I0:P50,C5]\nI: [I0:P60,C6]\nI: [I0:P70,C7]\nI: [I0:P80,C8]\nI: [I0:P90,C9]\nI: [I0:P100,C10]\n")
 	})
+
+	t.Run("test encoded progress with write interface", func(t *testing.T) {
+		Log := CaptureLog(t)
+		defer Log.Release()
+
+		text := "ProgressWriter: Write interface"
+		length := int64(len(text))
+		instCnt := 0
+		fileBase := "Testing"
+		progressWriter := utils.NewEncodedProgress(length, instCnt, fileBase)
+
+		fmt.Fprint(progressWriter, text)
+
+		assert.True(gText == "I: [I0:FTesting,T31,P100]\n")
+	})
+
 }

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -30,14 +30,14 @@ import (
 	"golang.org/x/net/html/charset"
 )
 
-var g_encodedProgress = false
+var gEncodedProgress = false
 
 func SetEncodedProgress(encodedProgress bool) {
-	g_encodedProgress = encodedProgress
+	gEncodedProgress = encodedProgress
 }
 
 func GetEncodedProgress() bool {
-	return g_encodedProgress
+	return gEncodedProgress
 }
 
 // CacheDir is used for cpackget to temporarily host downloaded pack files


### PR DESCRIPTION
Usage: 
Available for commands: init, add, update-index: "--encoded-progress"
e.g.: cpackget add Keil::STM32C0xx_DFP --encoded-progress


```
/* Encodes information to show progress when called by GUI or other tools
 * I: Instance number (always counts up), connected to the filename
 * F: Filename currently processed
 * T: Total bytes of file or numbers of files
 * P: Currently processed percentage
 * C: Currently processed bytes or numbers of files */
```