### PR TITLE
[cpackget] add command shall download the pack and extract the license files to .Download #196

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -174,7 +174,7 @@ func NewCli() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run cpackget silently, printing only error messages")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
 	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable")
-	rootCmd.PersistentFlags().UintP("concurrent-downloads", "C", 5, "Number of concurrent batch downloads. Set to 0 to disable concurrency")
+	rootCmd.PersistentFlags().UintP("concurrent-downloads", "C", 0, "Number of concurrent batch downloads. Set to 0 to disable concurrency")
 	rootCmd.PersistentFlags().UintP("timeout", "T", 0, "Set maximum duration (in seconds) of a download. Disabled by default")
 	_ = viper.BindPFlag("concurrent-downloads", rootCmd.PersistentFlags().Lookup("concurrent-downloads"))
 	_ = viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))

--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -94,4 +94,7 @@ var (
 
 	// Error/Flag to detect when a user has requested early termination
 	ErrTerminatedByUser = errors.New("terminated by user request")
+
+	ErrReadingPdsc     = errors.New("reading PDSC failed")
+	ErrDownloadingPdsc = errors.New("download of some PDSC failed, please run 'cpackget update-index -a'") // add: -C 0
 )

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/lu4p/cat"
-	"github.com/open-cmsis-pack/cpackget/cmd/errors"
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/open-cmsis-pack/cpackget/cmd/ui"
 	"github.com/open-cmsis-pack/cpackget/cmd/utils"
@@ -473,7 +472,7 @@ func (p *PackType) extractEula(packPath string) error {
 	}
 	if utils.FileExists(eulaFileName) {
 		log.Errorf("Cannot remove previous copy of license file: \"%s\"", eulaFileName)
-		return errors.ErrFailedCreatingFile
+		return errs.ErrFailedCreatingFile
 	}
 
 	return os.WriteFile(eulaFileName, eulaContents, utils.FileModeRO)

--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/lu4p/cat"
+	"github.com/open-cmsis-pack/cpackget/cmd/errors"
 	errs "github.com/open-cmsis-pack/cpackget/cmd/errors"
 	"github.com/open-cmsis-pack/cpackget/cmd/ui"
 	"github.com/open-cmsis-pack/cpackget/cmd/utils"
@@ -460,7 +461,20 @@ func (p *PackType) extractEula(packPath string) error {
 
 	eulaFileName := packPath + "." + path.Base(p.Pdsc.License)
 
-	log.Infof("Extracting embedded license to %v", eulaFileName)
+	if utils.GetEncodedProgress() {
+		log.Infof("[L:F\"%s\"]", eulaFileName)
+	} else {
+		log.Infof("Extracting embedded license to %v", eulaFileName)
+	}
+
+	if utils.FileExists(eulaFileName) {
+		utils.UnsetReadOnly(eulaFileName)
+		os.Remove(eulaFileName)
+	}
+	if utils.FileExists(eulaFileName) {
+		log.Errorf("Cannot remove previous copy of license file: \"%s\"", eulaFileName)
+		return errors.ErrFailedCreatingFile
+	}
 
 	return os.WriteFile(eulaFileName, eulaContents, utils.FileModeRO)
 }

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -304,7 +304,9 @@ func DownloadPDSCFiles(skipInstalledPdscFiles bool, concurrency int, timeout int
 		return nil
 	}
 
-	log.Infof("[J%d:F\"%s\"]", numPdsc, Installation.PublicIndex)
+	if utils.GetEncodedProgress() {
+		log.Infof("[J%d:F\"%s\"]", numPdsc, Installation.PublicIndex)
+	}
 
 	queue := concurrency
 	for _, pdscTag := range pdscTags {
@@ -1087,8 +1089,10 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, skipInstal
 
 	if skipInstalledPdscFiles {
 		if utils.FileExists(pdscFilePath) {
+			log.Debugf("File already exists: \"%s\"", pdscFilePath)
 			return nil
 		}
+		log.Debugf("File does not exist and will be copied: \"%s\"", pdscFilePath)
 	}
 
 	pdscURL := pdscTag.URL
@@ -1119,6 +1123,11 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, skipInstal
 	utils.UnsetReadOnly(pdscFilePath)
 	err = utils.MoveFile(localFileName, pdscFilePath)
 	utils.SetReadOnly(pdscFilePath)
+
+	if !utils.FileExists(pdscFilePath) {
+		log.Errorf("File was not copied: \"%s\"", pdscFilePath)
+	}
+
 	return err
 }
 

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -511,6 +511,7 @@ func TestAddPack(t *testing.T) {
 			CheckEula:   true,
 			ExtractEula: true,
 		})
+		assert.True(utils.FileExists(extractedLicensePath))
 
 		addPack(t, packPath, ConfigType{
 			CheckEula:   true,

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -496,6 +496,32 @@ func TestAddPack(t *testing.T) {
 		os.Remove(extractedLicensePath)
 	})
 
+	t.Run("test installing pack with license extracted but prev license exist", func(t *testing.T) {
+		localTestingDir := "test-add-pack-with-license-extracted-but-prev-license-exist"
+		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))
+		installer.UnlockPackRoot()
+		defer removePackRoot(localTestingDir)
+
+		packPath := packWithLicense
+
+		extractedLicensePath := filepath.Join(installer.Installation.DownloadDir, filepath.Base(packPath)+".LICENSE.txt")
+
+		ui.LicenseAgreed = nil
+		addPack(t, packPath, ConfigType{
+			CheckEula:   true,
+			ExtractEula: true,
+		})
+
+		addPack(t, packPath, ConfigType{
+			CheckEula:   true,
+			ExtractEula: true,
+		})
+
+		assert.True(utils.FileExists(extractedLicensePath))
+
+		os.Remove(extractedLicensePath)
+	})
+
 	t.Run("test installing pack with missing license", func(t *testing.T) {
 		// Missing license means it is specified in the PDSC file, but the actual license
 		// file is not there

--- a/cmd/ui/eula.go
+++ b/cmd/ui/eula.go
@@ -40,6 +40,10 @@ type LicenseWindowType struct {
 // DisplayAndWaitForEULA prints out the license to the user through a UI
 // and waits for user confirmation.
 func DisplayAndWaitForEULA(licenseTitle, licenseContents string) (bool, error) {
+	if Extract {
+		return false, errs.ErrExtractEula
+	}
+
 	promptText := "License Agreement: [A]ccept [D]ecline [E]xtract"
 
 	if !utils.IsTerminalInteractive() {

--- a/cmd/utils/encodedProgress.go
+++ b/cmd/utils/encodedProgress.go
@@ -46,6 +46,7 @@ func (p *EncodedProgress) Write(bs []byte) (int, error) {
  * P: Currently processed percentage
  * C: Currently processed bytes or numbers of files
  * J: Total number of files beeing processed
+ * L: License file follows
  */
 func (p *EncodedProgress) Print() {
 	newPercent := int(float64(p.current) / float64(p.total) * 100)


### PR DESCRIPTION
cpackget is already prepared to just extract the EULA and then quit, and to auto-accept EULA in a next step. Changed the program flow to skip showing the license / preparing the license UI if already the command line specifies the extract option.

If the license file already exists it will be deleted (error if not possible).

Added for encoded progress:
* L: License file follows I: [L:F"C:\Users\user\AppData\Local\Arm\Packs\.Download\Keil.MDK-Middleware_Graphics.1.3.0.pack.license.rtf"]

see https://github.com/Open-CMSIS-Pack/cpackget/issues/196