### PR TITLE
[cpackget] --concurrent-downloads (default 5) corrupts downloaded *.pdsc files #197

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -174,7 +174,7 @@ func NewCli() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "Run cpackget silently, printing only error messages")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Sets verboseness level: None (Errors + Info + Warnings), -v (all + Debugging). Specify \"-q\" for no messages")
 	rootCmd.PersistentFlags().StringP("pack-root", "R", defaultPackRoot, "Specifies pack root folder. Defaults to CMSIS_PACK_ROOT environment variable")
-	rootCmd.PersistentFlags().UintP("concurrent-downloads", "C", 5, "Number of concurrent batch downloads. Set to 0 to disable concurrency")
+	rootCmd.PersistentFlags().UintP("concurrent-downloads", "C", 20, "Number of concurrent batch downloads. Set to 0 to disable concurrency")
 	rootCmd.PersistentFlags().UintP("timeout", "T", 0, "Set maximum duration (in seconds) of a download. Disabled by default")
 	_ = viper.BindPFlag("concurrent-downloads", rootCmd.PersistentFlags().Lookup("concurrent-downloads"))
 	_ = viper.BindPFlag("timeout", rootCmd.PersistentFlags().Lookup("timeout"))

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -1153,10 +1153,6 @@ func (p *PacksInstallationType) downloadPdscFile(pdscTag xml.PdscTag, skipInstal
 	err = utils.MoveFile(localFileName, pdscFilePath)
 	utils.SetReadOnly(pdscFilePath)
 
-	if err != nil {
-		return err
-	}
-
 	return err
 }
 

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -315,6 +315,9 @@ func DownloadPDSCFiles(skipInstalledPdscFiles bool, concurrency int, timeout int
 		if maxWorkers > concurrency {
 			maxWorkers = concurrency
 		}
+		if maxWorkers == 0 {
+			concurrency = 0
+		}
 	}
 
 	sem := semaphore.NewWeighted(int64(maxWorkers))
@@ -356,6 +359,9 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 	if concurrency > 1 {
 		if maxWorkers > concurrency {
 			maxWorkers = concurrency
+		}
+		if maxWorkers == 0 {
+			concurrency = 0
 		}
 	}
 

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -21,7 +21,6 @@ import (
 	"github.com/open-cmsis-pack/cpackget/cmd/xml"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/mod/semver"
-	"golang.org/x/sync/semaphore"
 )
 
 const KeilDefaultPackRoot = "https://www.keil.com/pack/"
@@ -310,24 +309,22 @@ func DownloadPDSCFiles(skipInstalledPdscFiles bool, concurrency int, timeout int
 		log.Infof("[J%d:F\"%s\"]", numPdsc, Installation.PublicIndex)
 	}
 
-	ctx := context.TODO()
 	maxWorkers := runtime.GOMAXPROCS(0)
 	if maxWorkers > concurrency {
 		maxWorkers = concurrency
 	}
-	sem := semaphore.NewWeighted(int64(maxWorkers))
-
+	cnt := int(0)
 	for _, pdscTag := range pdscTags {
-		if err := sem.Acquire(ctx, 1); err != nil {
-			log.Errorf("Failed to acquire semaphore: %v", err)
-			break
-		}
-
 		go func(pdscTag xml.PdscTag) {
-			defer sem.Release(1)
 			wg.Add(1)
 			massDownloadPdscFiles(pdscTag, skipInstalledPdscFiles, &wg, timeout)
 		}(pdscTag)
+
+		cnt++
+		if cnt > maxWorkers {
+			cnt = 0
+			wg.Wait()
+		}
 	}
 	wg.Wait()
 
@@ -347,7 +344,6 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 	if maxWorkers > concurrency {
 		maxWorkers = concurrency
 	}
-	sem := semaphore.NewWeighted(int64(maxWorkers))
 
 	for _, pdscFile := range pdscFiles {
 		log.Debugf("Checking if \"%s\" needs updating", pdscFile)
@@ -374,22 +370,24 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 			continue
 		}
 
+		cnt := int(0)
 		versionInIndex := tags[0].Version
 		latestVersion := pdscXML.LatestVersion()
 		if versionInIndex != latestVersion {
 			log.Infof("%s::%s can be upgraded from \"%s\" to \"%s\"", pdscXML.Vendor, pdscXML.Name, latestVersion, versionInIndex)
 
-			if err := sem.Acquire(ctx, 1); err != nil {
-				log.Errorf("Failed to acquire semaphore: %v", err)
-				break
-			}
 			wg.Add(1)
 
 			pdscTag := tags[0]
 			go func(pdscTag xml.PdscTag) {
-				defer sem.Release(1)
 				massDownloadPdscFiles(pdscTag, false, &wg, timeout)
 			}(pdscTag)
+
+			cnt++
+			if cnt > maxWorkers {
+				cnt = 0
+				wg.Wait()
+			}
 		}
 	}
 

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -4,7 +4,6 @@
 package installer
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -315,8 +314,8 @@ func DownloadPDSCFiles(skipInstalledPdscFiles bool, concurrency int, timeout int
 	}
 	cnt := int(0)
 	for _, pdscTag := range pdscTags {
+		wg.Add(1)
 		go func(pdscTag xml.PdscTag) {
-			wg.Add(1)
 			massDownloadPdscFiles(pdscTag, skipInstalledPdscFiles, &wg, timeout)
 		}(pdscTag)
 
@@ -339,7 +338,6 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 		return err
 	}
 
-	ctx := context.TODO()
 	maxWorkers := runtime.GOMAXPROCS(0)
 	if maxWorkers > concurrency {
 		maxWorkers = concurrency
@@ -377,7 +375,6 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 			log.Infof("%s::%s can be upgraded from \"%s\" to \"%s\"", pdscXML.Vendor, pdscXML.Name, latestVersion, versionInIndex)
 
 			wg.Add(1)
-
 			pdscTag := tags[0]
 			go func(pdscTag xml.PdscTag) {
 				massDownloadPdscFiles(pdscTag, false, &wg, timeout)

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -335,7 +335,10 @@ func DownloadPDSCFiles(skipInstalledPdscFiles bool, concurrency int, timeout int
 		}
 	}
 	if maxWorkers > 1 {
-		wg.Wait()
+		//	wg.Wait()
+		if err := sem.Acquire(ctx, int64(maxWorkers)); err != nil {
+			log.Errorf("Failed to acquire semaphore: %v", err)
+		}
 	}
 
 	return nil
@@ -405,7 +408,10 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 	}
 
 	if maxWorkers > 1 {
-		wg.Wait()
+		//	wg.Wait()
+		if err := sem.Acquire(ctx, int64(maxWorkers)); err != nil {
+			log.Errorf("Failed to acquire semaphore: %v", err)
+		}
 	}
 
 	return nil

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -357,6 +357,11 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 		return err
 	}
 
+	numPdsc := len(pdscFiles)
+	if utils.GetEncodedProgress() {
+		log.Infof("[J%d:F\"%s\"]", numPdsc, Installation.PublicIndex)
+	}
+
 	ctx := context.TODO()
 	concurrency = CheckConcurrency(concurrency)
 	sem := semaphore.NewWeighted(int64(concurrency))

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -391,7 +391,7 @@ func UpdateInstalledPDSCFiles(pidxXML *xml.PidxXML, concurrency int, timeout int
 		if versionInIndex != latestVersion {
 			log.Infof("%s::%s can be upgraded from \"%s\" to \"%s\"", pdscXML.Vendor, pdscXML.Name, latestVersion, versionInIndex)
 
-			if maxWorkers == 0 {
+			if concurrency == 0 {
 				massDownloadPdscFiles(tags[0], false, timeout)
 			} else {
 				if err := sem.Acquire(ctx, 1); err != nil {

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -588,6 +588,7 @@ func TestUpdatePublicIndex(t *testing.T) {
 	t.Run("test check concurrency function call", func(t *testing.T) {
 		assert.Equal(installer.CheckConcurrency(0), 0)
 		assert.Equal(installer.CheckConcurrency(5), 5)
+		assert.NotEqual(installer.CheckConcurrency(999999), 5)
 	})
 
 	t.Run("test add remote index.pidx and dowload pdsc files", func(t *testing.T) {

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -585,6 +585,11 @@ func TestUpdatePublicIndex(t *testing.T) {
 		assert.Equal(copied, indexContent)
 	})
 
+	t.Run("test check concurrency function call", func(t *testing.T) {
+		assert.Equal(installer.CheckConcurrency(0), 0)
+		assert.Equal(installer.CheckConcurrency(5), 5)
+	})
+
 	t.Run("test add remote index.pidx and dowload pdsc files", func(t *testing.T) {
 		localTestingDir := "test-add-remote-index-download-pdsc"
 		assert.Nil(installer.SetPackRoot(localTestingDir, CreatePackRoot))

--- a/cmd/installer/root_test.go
+++ b/cmd/installer/root_test.go
@@ -586,9 +586,9 @@ func TestUpdatePublicIndex(t *testing.T) {
 	})
 
 	t.Run("test check concurrency function call", func(t *testing.T) {
-		assert.Equal(installer.CheckConcurrency(0), 0)
-		assert.Equal(installer.CheckConcurrency(5), 5)
-		assert.NotEqual(installer.CheckConcurrency(999999), 5)
+		assert.Equal(0, installer.CheckConcurrency(0))
+		assert.Equal(2, installer.CheckConcurrency(2))
+		assert.NotEqual(999999, installer.CheckConcurrency(999999))
 	})
 
 	t.Run("test add remote index.pidx and dowload pdsc files", func(t *testing.T) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,6 @@ func main() {
 		os.Exit(-1)
 	}
 
-	log.Debugf("took %v", time.Since(start))
+	log.Debugf("Took %v", time.Since(start))
 	utils.StopSignalWatcher()
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,6 +31,6 @@ func main() {
 		os.Exit(-1)
 	}
 
-	log.Debugf("Took %v", time.Since(start))
+	log.Debugf("took %v", time.Since(start))
 	utils.StopSignalWatcher()
 }

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/mod v0.7.0
 	golang.org/x/net v0.7.0
+	golang.org/x/sync v0.1.0
 	golang.org/x/term v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/makefile
+++ b/makefile
@@ -92,7 +92,7 @@ coverage-report: test
 
 coverage-check: test
 	@echo Checking if test coverage is atleast 85%
-	test `go tool cover -func cover.out | tail -1 | awk '{print ($$3 + 0)*10}'` -ge 800
+	test `go tool cover -func cover.out | tail -1 | awk '{print ($$3 + 0)*10}'` -ge 840
 
 test-public-index:
 	@./scripts/test-public-index

--- a/makefile
+++ b/makefile
@@ -92,7 +92,7 @@ coverage-report: test
 
 coverage-check: test
 	@echo Checking if test coverage is atleast 85%
-	test `go tool cover -func cover.out | tail -1 | awk '{print ($$3 + 0)*10}'` -ge 850
+	test `go tool cover -func cover.out | tail -1 | awk '{print ($$3 + 0)*10}'` -ge 800
 
 test-public-index:
 	@./scripts/test-public-index


### PR DESCRIPTION
fixed:
- concurrent download scheduler
- added tests on downloaded files