### PR TITLE
Update TPIP schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,6 @@ on:
     tags:
       - "v*"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/tpip-check.yml
+++ b/.github/workflows/tpip-check.yml
@@ -9,6 +9,8 @@ on:
       - "**/go.sum"
       - "scripts/template/**"
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   report_name: "third_party_licenses.md"
@@ -35,7 +37,6 @@ jobs:
       - name: Generate TPIP Report
         run:  |
           go-licenses report . --ignore github.com/Open-CMSIS-Pack/cpackget --template ../scripts/template/tpip-license.template > ../${{ env.report_name }}
-          date +"%Y/%m/%d %T" >> ../${{ env.report_name }}
         working-directory: ./cmd
         
       - name: Archive tpip report
@@ -52,6 +53,10 @@ jobs:
         working-directory: ./cmd
 
   commit-changes:
+    # Running this job only on specific event
+    # in order to have workaround for issue
+    # related to deletion of GH checks/status data
+    if: (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch')
     needs: [ check-licenses ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -65,12 +70,15 @@ jobs:
         with:
           name: tpip-report
 
-      - name: Commit Changes
-        shell: bash
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .
-          git commit -m "Update TPIP report"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Update TPIP report
+          title: ':robot: [TPIP] Automated report updates'
+          body: |
+            Third party IP report updates
+          branch: update-tpip
+          delete-branch: true
+          labels: TPIP
+          reviewers: soumeh01
       

--- a/scripts/template/tpip-license.template
+++ b/scripts/template/tpip-license.template
@@ -6,4 +6,4 @@
 | {{ .Name }} | {{ .Version }}  | [{{ .LicenseName }}]({{ .LicenseURL }}) |
 {{- end }}
 
-Report generated and repository checked for [forbidden](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L323) and [restricted](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L176) licenses on: 
+Report generated and repository checked for [forbidden](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L323) and [restricted](https://github.com/google/licenseclassifier/blob/842c0d70d7027215932deb13801890992c9ba364/license_type.go#L176) licenses.


### PR DESCRIPTION
Run TPIP workflow nightly. It will create a PR only when it finds a change in the go packages used (Nightly or on Manual trigger)
Also for simplicity of the solution, we have removed the timestamp from the report.