### PR TITLE
Pack Installer fails to install packs with a backslash in the license file path

### DIFF
--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -457,7 +456,7 @@ func (p *PackType) extractEula(packPath string) error {
 		return err
 	}
 
-	eulaFileName := packPath + "." + path.Base(p.Pdsc.License)
+	eulaFileName := packPath + "." + filepath.Base(p.Pdsc.License)
 
 	if utils.GetEncodedProgress() {
 		log.Infof("[L:F\"%s\"]", eulaFileName)


### PR DESCRIPTION
fixed:
golang "path" object has issues handling backslash, changed to filepath object.

also see: https://github.com/Open-CMSIS-Pack/cpackget/issues/232