### PR TITLE
Adapt new upload action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           make OS=${{ matrix.goos }} ARCH=${{ matrix.arch }} build
 
       - name: Upload binary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpackget-${{ matrix.goos }}-${{ matrix.arch }}
           path: build/cpackget*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,10 +134,10 @@ jobs:
           prefix: github.com/open-cmsis-pack/cpackget
 
       - name: Archive unit test results
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
-          path: ./build/cpackget-testreport-*.xml
+          name: test-results-${{ matrix.goos }}-amd64
+          path: ./build/cpackget-testreport-${{ matrix.goos }}-amd64.xml
           if-no-files-found: error
 
   test-linux-arm64:
@@ -185,9 +185,8 @@ jobs:
           go-junit-report -set-exit-code -in ${PWD}/artifacts/cpackgettests-linux-arm64.txt -iocopy -out ./cpackget-testreport-linux-arm64.xml
   
       - name: Archive unit test results
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
-          name: test-results
+          name: test-results-linux-arm64
           path: ./cpackget-testreport-linux-arm64.xml
           if-no-files-found: error
-

--- a/.github/workflows/tpip-check.yml
+++ b/.github/workflows/tpip-check.yml
@@ -40,7 +40,7 @@ jobs:
         working-directory: ./cmd
         
       - name: Archive tpip report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tpip-report
           path: ./${{ env.report_name }}


### PR DESCRIPTION
New version (v4) of upload action has a breaking change regarding [Uploading to the same named Artifact multiple times](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). Hence we need to adapt the new changes.