### PR TITLE
Fixed lint and vuln check issues

### DIFF
--- a/cmd/ui/eula.go
+++ b/cmd/ui/eula.go
@@ -64,7 +64,7 @@ func DisplayAndWaitForEULA(licenseTitle, licenseContents string) (bool, error) {
 		}
 
 		var input string
-		fmt.Scanln(&input)
+		_, _ = fmt.Scanln(&input)
 
 		if input == "a" || input == "A" {
 			return true, nil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-cmsis-pack/cpackget
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.7.5


### PR DESCRIPTION
Addressing :
**Linter issue:**
`Error: Error return value of `fmt.Scanln` is not checked (errcheck)`

**Vulnerability detected:**
```
Vulnerability #1: GO-2024-2888
    Mishandling of corrupt central directory record in archive/zip
  More info: https://pkg.go.dev/vuln/GO-2024-2888
  Standard library
    Found in: archive/zip@go1.22.3
    Fixed in: archive/zip@go1.22.4
    Example traces found:
Error:       #1: cmd/installer/pack.go:450:36: installer.PackType.checkEula calls cat.FromBytes, which eventually calls zip.NewReader
Error:       #2: cmd/cryptography/signature.go:520:28: cryptography.VerifyPackSignature calls zip.OpenReader

Vulnerability #2: GO-2024-2887
    Unexpected behavior from Is methods for IPv4-mapped IPv6 addresses in
    net/netip
  More info: https://pkg.go.dev/vuln/GO-2024-2887
  Standard library
    Found in: net/netip@go1.22.3
    Fixed in: net/netip@go1.22.4
    Example traces found:
Error:       #1: cmd/utils/utils.go:77:32: utils.RoundTrip calls http.Transport.RoundTrip, which eventually calls netip.Addr.IsLoopback
Error:       #2: cmd/utils/utils.go:77:32: utils.RoundTrip calls http.Transport.RoundTrip, which eventually calls netip.Addr.IsMulticast
```