### PR TITLE
[cpackget] Add `User-Agent` header in HTTP GET requests when downloading a pack

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,6 +22,7 @@ func main() {
 
 	commands.Version = version
 	commands.Copyright = copyRight
+	utils.SetUserAgent("cpackget/" + version)
 	cmd := commands.NewCli()
 	err := cmd.Execute()
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,7 +22,7 @@ func main() {
 
 	commands.Version = version
 	commands.Copyright = copyRight
-	utils.SetUserAgent("cpackget/" + version)
+	utils.SetUserAgent("CMSIS-Toolbox cpackget/" + version)
 	cmd := commands.NewCli()
 	err := cmd.Execute()
 	if err != nil {

--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -32,6 +32,7 @@ import (
 
 var gEncodedProgress = false
 var gSkipTouch = false
+var gUserAgent string
 
 func SetEncodedProgress(encodedProgress bool) {
 	gEncodedProgress = encodedProgress
@@ -47,6 +48,10 @@ func SetSkipTouch(skipTouch bool) {
 
 func GetSkipTouch() bool {
 	return gSkipTouch
+}
+
+func SetUserAgent(userAgent string) {
+	gUserAgent = userAgent
 }
 
 // CacheDir is used for cpackget to temporarily host downloaded pack files
@@ -139,7 +144,9 @@ func DownloadFile(URL string, timeout int) (string, error) {
 		},
 	}
 
-	resp, err := client.Get(URL)
+	req, _ := http.NewRequest("GET", URL, nil)
+	req.Header.Add("User-Agent", gUserAgent)
+	resp, err := client.Do(req)
 	if err != nil {
 		log.Error(err)
 		return "", fmt.Errorf("\"%s\": %w", URL, errs.ErrFailedDownloadingFile)


### PR DESCRIPTION
It seems Analog Devices are blocking some specific HTTP GET requests, in particular when the `User-Agent` header is absent or set to `Go-http-client/1.1`.

Trying to download an Analog Devices pack fails:
```
cpackget add -a AnalogDevices::ADuCM320_DFP@1.1.1
...
E: failed to download file
```
Also the following curl commands fail with similar behaviour:
```
curl -LO 'https://download.analog.com/tools/EZBoards/ADuCM32x/Releases/AnalogDevices.ADuCM320_DFP.1.1.1.pack'
curl -LO 'https://download.analog.com/tools/EZBoards/ADuCM32x/Releases/AnalogDevices.ADuCM320_DFP.1.1.1.pack' -H 'User-Agent: Go-http-client/1.1'
```

This PR sets the `User-Agent` header to `cpackget/<version>`.