### PR TITLE
Use update cfg

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -69,7 +69,7 @@ func configureInstaller(cmd *cobra.Command, args []string) error {
 	targetPackRoot := viper.GetString("pack-root")
 	checkConnection := viper.GetBool("check-connection") // TODO: never set
 
-	download := cmd.Name() != "init" && cmd.Name() != "update-index" && cmd.Name() != "connection"
+	download := cmd.Name() != "init" && cmd.Name() != "update-index" && cmd.Name() != "rm" && cmd.Name() != "list" && cmd.Name() != "connection"
 
 	if targetPackRoot == installer.GetDefaultCmsisPackRoot() {
 		// If using the default pack root path and the public index is not found,
@@ -80,7 +80,7 @@ func configureInstaller(cmd *cobra.Command, args []string) error {
 				return err
 			}
 			// Exclude index updating commands to not double update
-			if cmd.Name() != "init" && cmd.Name() != "index" && cmd.Name() != "update-index" {
+			if cmd.Name() != "init" && cmd.Name() != "index" && cmd.Name() != "update-index" && cmd.Name() != "rm" && cmd.Name() != "list" {
 				installer.UnlockPackRoot()
 				err = installer.UpdatePublicIndex(installer.DefaultPublicIndex, true, true, false, false, 0, 0)
 				if err != nil {

--- a/cmd/installer/root_pack_add_test.go
+++ b/cmd/installer/root_pack_add_test.go
@@ -677,7 +677,8 @@ func TestAddPack(t *testing.T) {
 			err = installer.AddPack(packPath, !CheckEula, !ExtractEula, !ForceReinstall, !NoRequirements, Timeout)
 
 			assert.NotNil(err)
-			assert.Equal(errors.Unwrap(err), errs.ErrPackPdscCannotBeFound)
+			//			assert.Equal(errors.Unwrap(err), errs.ErrPackPdscCannotBeFound)
+			assert.Equal(errors.Unwrap(err), errs.ErrBadRequest)
 
 			// Make sure pack.idx never got touched
 			assert.False(utils.FileExists(installer.Installation.PackIdx))


### PR DESCRIPTION
## Fixes
- use update.cfg instead of index.pidx timestamp
- do not update with rm and list
- corrected tests

## Changes
-

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [ ] 📖 All documentation updates are complete.
- [ ] 🧠 This change does not change third-party dependencies
