### PR TITLE
[cpackget] Retry download without `User-Agent` header

### DIFF
--- a/cmd/utils/utils.go
+++ b/cmd/utils/utils.go
@@ -152,6 +152,16 @@ func DownloadFile(URL string, timeout int) (string, error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusNotFound {
+		// resend GET request without user agent header
+		req.Header.Del("User-Agent")
+		resp, err = client.Do(req)
+		if err != nil {
+			log.Error(err)
+			return "", fmt.Errorf("\"%s\": %w", URL, errs.ErrFailedDownloadingFile)
+		}
+	}
+
 	if resp.StatusCode == http.StatusForbidden {
 		cookie := resp.Header.Get("Set-Cookie")
 		if len(cookie) > 0 {


### PR DESCRIPTION
## Fixes
<!-- List the issue(s) this PR resolves -->

- https://github.com/Open-CMSIS-Pack/cpackget/issues/412

## Changes
<!-- List the changes this PR introduces -->

- Resend the HTTP GET request without user agent header when the first attempt with `User-Agent: cpackget/v<version>` fails with status code `StatusNotFound`

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->

- [x] 🤖 This change is covered by unit tests as required.
- [x] 🤹 All required manual testing has been performed.
- [x] 🛡️ Security impacts have been considered.
- [x] 📖 All documentation updates are complete.
- [x] 🧠 This change does not change third-party dependencies
