### PR TITLE
fixed "not installed required packs" #386

### DIFF
--- a/cmd/installer/pack.go
+++ b/cmd/installer/pack.go
@@ -583,6 +583,8 @@ func (p *PackType) resolveVersionModifier(pdscXML *xml.PdscXML) {
 				return
 			}
 		}
+		log.Errorf("No compatible version available for pack version %s", utils.FormatVersions(p.Version))
+		return
 	}
 
 	log.Warn("Could not resolve version modifier")

--- a/cmd/utils/packs.go
+++ b/cmd/utils/packs.go
@@ -168,7 +168,7 @@ type PackInfo struct {
 //
 //	pack name, with "my" for vendor and "pack" for pack name.
 func ExtractPackInfo(packPath string) (PackInfo, error) {
-	log.Debugf("Extracting pack info from \"%s\"", packPath)
+	log.Debugf("Extracting pack info from \"%s\"", FormatVersions(packPath))
 
 	info := PackInfo{}
 	maxVersion := ""
@@ -264,7 +264,7 @@ func ExtractPackInfo(packPath string) (PackInfo, error) {
 		info.Version = version
 	}
 
-	log.Debugf("\"%s\" is a packID with Vendor=\"%s\", Pack=\"%s\", Version=\"%s\", VersionModifier=\"%v\"", packPath, info.Vendor, info.Pack, info.Version, info.VersionModifier)
+	log.Debugf("\"%s\" is a packID with Vendor=\"%s\", Pack=\"%s\", Version=\"%s\", VersionModifier=\"%v\"", packPath, info.Vendor, info.Pack, FormatVersions(info.Version), info.VersionModifier)
 	return info, nil
 }
 
@@ -291,4 +291,12 @@ func FormatPackVersion(pack []string) string {
 			}
 		}
 	}
+}
+
+func FormatVersions(version string) string {
+	s := strings.Split(version, ":")
+	if len(s) > 1 && s[1] == "_" {
+		return ">=" + s[0]
+	}
+	return version
 }

--- a/cmd/xml/pdsc.go
+++ b/cmd/xml/pdsc.go
@@ -160,8 +160,8 @@ func (p *PdscXML) Dependencies() [][]string {
 					pk.Version = pk.Version + ":_"
 				}
 			}
+			log.Debugf("found [%s %s %s] dependency", pk.Name, pk.Vendor, utils.FormatVersions(pk.Version))
 			dependency := []string{pk.Name, pk.Vendor, pk.Version}
-			log.Debugf("found %v dependency", dependency)
 			dependencies = append(dependencies, dependency)
 		}
 	}


### PR DESCRIPTION
## Fixes
#386 

## Changes
update not only index.pidx but also old pdsc in .web
fixed missing check for range comparison => error if not in range
display range 1.2.3:_ as >=1.2.3 in messages

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
