### PR TITLE
issue #411 change help screen header to version and copyright

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -115,8 +115,12 @@ var flags struct {
 var Version string
 var Copyright string
 
+func getLongHelpDescription() string {
+	return fmt.Sprintf("cpackget version %v %s\n", strings.ReplaceAll(Version, "v", ""), Copyright)
+}
+
 func printVersionAndLicense(file io.Writer) {
-	fmt.Fprintf(file, "cpackget version %v %s\n", strings.ReplaceAll(Version, "v", ""), Copyright)
+	file.Write([]byte(getLongHelpDescription()))
 }
 
 // UsageTemplate returns usage template for the command.
@@ -148,7 +152,7 @@ func NewCli() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:           "cpackget [command] [flags]",
 		Short:         "This utility adds/removes CMSIS-Packs",
-		Long:          "Please refer to the upstream repository for further information: https://github.com/Open-CMSIS-Pack/cpackget.",
+		Long:          getLongHelpDescription(),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Fixes
#411

## Changes
changed 1st line of help screen to copright notice

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [ ] 🛡️ Security impacts have been considered (if relevant).
- [ ] 📖 Documentation updates are complete (if required).
- [ ] 🧠 Third-party dependencies and TPIP updated (if required).
