### PR TITLE
Updated minimum golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-cmsis-pack/cpackget
 
-go 1.22.5
+go 1.24.0
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.8.3


### PR DESCRIPTION
Updated the supported Go version to the latest release. Many project dependencies were no longer compatible with the older Go version, and updating them was necessary to address security vulnerabilities.

For example, [golang.org/x/net](https://github.com/Open-CMSIS-Pack/cpackget/security/dependabot/12) required an update due to identified security risks.

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [N/A] 🤖 This change is covered by unit tests (if applicable).
- [N/A] 🤹 Manual testing has been performed (if necessary).
- [N/A] 🛡️ Security impacts have been considered (if relevant).
- [N/A] 📖 Documentation updates are complete (if required).
- [N/A] 🧠 Third-party dependencies and TPIP updated (if required).
