### PR TITLE
check pdsc files in a pack and correct version compare

### DIFF
--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -32,16 +32,18 @@ var (
 	ErrBadPackVersion = errors.New("bad pack version: cannot add a version with build metadata")
 
 	// Errors related to package content
-	ErrPdscFileNotFound      = errors.New("pdsc not found")
-	ErrPackNotInstalled      = errors.New("pack not installed")
-	ErrPdscEntryExists       = errors.New("pdsc already in index")
-	ErrPdscEntryNotFound     = errors.New("pdsc not found in index")
-	ErrEula                  = errors.New("user does not agree with the pack's license")
-	ErrExtractEula           = errors.New("user wants to extract embedded license only")
-	ErrLicenseNotFound       = errors.New("embedded license not found")
-	ErrPackRootNotFound      = errors.New("no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option -R/--pack-root string")
-	ErrPackRootDoesNotExist  = errors.New("the specified CMSIS Pack Root directory does NOT exist! Please take a moment to review if the value is correct or create a new one via `cpackget init` command")
-	ErrPdscFileTooDeepInPack = errors.New("pdsc file is too deep in pack file")
+	ErrPdscFileNotFound        = errors.New("pdsc not found")
+	ErrPackNotInstalled        = errors.New("pack not installed")
+	ErrPdscEntryExists         = errors.New("pdsc already in index")
+	ErrPdscEntryNotFound       = errors.New("pdsc not found in index")
+	ErrEula                    = errors.New("user does not agree with the pack's license")
+	ErrExtractEula             = errors.New("user wants to extract embedded license only")
+	ErrLicenseNotFound         = errors.New("embedded license not found")
+	ErrPackRootNotFound        = errors.New("no CMSIS Pack Root directory specified. Either the environment CMSIS_PACK_ROOT needs to be set or the path specified using the command line option -R/--pack-root string")
+	ErrPackRootDoesNotExist    = errors.New("the specified CMSIS Pack Root directory does NOT exist! Please take a moment to review if the value is correct or create a new one via `cpackget init` command")
+	ErrPdscFileTooDeepInPack   = errors.New("pdsc file is too deep in pack file")
+	ErrMultiplePdscFilesInPack = errors.New("multiple pdsc files found in pack file, cannot determine which one to use. Please remove the extra pdsc files")
+	ErrPdscWrongName           = errors.New("pdsc file has wrong name, it should be <PackID>.pdsc")
 
 	// Errors related to network
 	ErrBadRequest            = errors.New("bad request")

--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -1894,9 +1894,21 @@ func (p *PacksInstallationType) PackIsInstalled(pack *PackType, noLocal bool) (f
 		if latestVersion == "" {
 			log.Debugf("Could not find latest version for %q", pack.PackIDWithVersion())
 		} else {
+			log.Debugf("Checking for installed packs %s", utils.FormatVersions(pack.Version))
+			for _, version := range installedVersions {
+				log.Debugf("- checking against: %s", version)
+				if utils.SemverCompare(version, latestVersion) >= 0 {
+					found = true
+					return
+				}
+			}
 			packDir := filepath.Join(installationDir, latestVersion)
 			found = utils.DirExists(packDir)
-			pack.targetVersion = latestVersion
+			if !found && utils.SemverCompare(latestVersion, pack.Version) >= 0 {
+				pack.targetVersion = latestVersion
+			} else {
+				pack.targetVersion = pack.Version
+			}
 		}
 	}
 


### PR DESCRIPTION
## Fixes
- check the position of pdsc files inside a pack for correctness
- corrected version compare with list --updatable and existing local pack installations

## Changes
- search a pack for existing pdsc files
- check version of local installations before those in the index

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [ ] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
