### PR TITLE
Remove old duplicate build constraints

### DIFF
--- a/cmd/installer/root_unix_test.go
+++ b/cmd/installer/root_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright Contributors to the cpackget project. */

--- a/cmd/installer/root_windows_test.go
+++ b/cmd/installer/root_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright Contributors to the cpackget project. */

--- a/cmd/utils/signal_unix_test.go
+++ b/cmd/utils/signal_unix_test.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright Contributors to the cpackget project. */

--- a/cmd/utils/signal_windows_test.go
+++ b/cmd/utils/signal_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Copyright Contributors to the cpackget project. */


### PR DESCRIPTION
## Changes
- Resolving the fix for 
```
buildtag: +build line is no longer needed (govet)
// +build !windows

```
## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
