### PR TITLE
replaced warning for missing update.cfg by a debug message and create…

### DIFF
--- a/cmd/installer/root.go
+++ b/cmd/installer/root.go
@@ -1760,8 +1760,7 @@ func (p *PacksInstallationType) checkUpdateCfg(conf *updateCfg, WarningInsteadOf
 	f, err := os.Open(filepath.Join(p.WebDir, "update.cfg"))
 	if err != nil {
 		if WarningInsteadOfErrors {
-			log.Warnf("Could not open update.cfg: %v", err)
-			return nil
+			log.Debugf("Could not open update.cfg: %v", err)
 		}
 		return err
 	}


### PR DESCRIPTION
… new update.cfg and do the first update like before

## Fixes
-

## Changes
- replaced warning for missing update.cfg by a debug message

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
