### PR TITLE
Better error message for pack ids not found in index

### DIFF
--- a/cmd/errors/errors.go
+++ b/cmd/errors/errors.go
@@ -96,7 +96,7 @@ var (
 	ErrPackVersionNotFoundInPdsc       = errors.New("pack version not found in the pdsc file")
 	ErrPackVersionNotLatestReleasePdsc = errors.New("pack version is not the latest in the pdsc file")
 	ErrPackVersionNotAvailable         = errors.New("target pack version is not available")
-	ErrPackURLCannotBeFound            = errors.New("the pack is not found in the public index. The command 'cpackget list --public' shows all public packs.")
+	ErrPackURLCannotBeFound            = errors.New("the pack is not found in the public index. The command 'cpackget list --public' shows all public packs")
 
 	// Hack to allow multiple error logs while still avoiding duplicating the last error log
 	ErrAlreadyLogged = errors.New("already logged")


### PR DESCRIPTION
## Fixes
- Open-CMSIS-Pack/cbuild/issues/536

## Changes
<!-- List the changes this PR introduces -->
- error message ErrPackURLCannotBeFound

## Checklist
<!-- Put an `x` in the boxes. All tasks must be completed and boxes checked before merging. -->
- [x] 🤖 This change is covered by unit tests (if applicable).
- [x] 🤹 Manual testing has been performed (if necessary).
- [x] 🛡️ Security impacts have been considered (if relevant).
- [x] 📖 Documentation updates are complete (if required).
- [x] 🧠 Third-party dependencies and TPIP updated (if required).
